### PR TITLE
Distinguish API credit limits, rate limits, and free trial requests

### DIFF
--- a/docs/knowledge-base/api/basics/api-key-access.mdx
+++ b/docs/knowledge-base/api/basics/api-key-access.mdx
@@ -22,10 +22,10 @@ curl -X GET "https://api.shovels.ai/v2/meta/release" \
 
 ## Free Trial API Access
 
-New accounts receive **250 credits** to explore our capabilities before committing to a paid plan.
+New accounts receive **250 free requests** to explore our capabilities before committing to a paid plan.
 
 <Info>
-Each record returned by the API counts against your credits. A search returning 100 permits uses 100 credits; a single permit lookup uses 1 credit.
+During the free trial, each API call counts as **1 request**, regardless of how many records are returned. Paid plans use a credit-based system where each record returned counts against your credits.
 </Info>
 
 ## Tracking Your Usage
@@ -41,5 +41,5 @@ If you hit your limit and need more credits:
 ## Related Articles
 
 - [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)
-- [API rate limits](/docs/knowledge-base/api/basics/rate-limits)
+- [API credit limits](/docs/knowledge-base/api/basics/credit-limits)
 - [API documentation](https://docs.shovels.ai/docs/shovels-api-introduction)

--- a/docs/knowledge-base/api/basics/automate-calls.mdx
+++ b/docs/knowledge-base/api/basics/automate-calls.mdx
@@ -48,7 +48,7 @@ Our [API documentation](/api-reference) provides code snippets in multiple langu
 
 ## Best Practices for Automation
 
-1. **Handle rate limits** - Implement backoff when approaching limits
+1. **Handle credit and rate limits** - Implement backoff when approaching limits
 2. **Use pagination** - Process large result sets in batches
 3. **Cache results** - Store data locally to minimize API calls
 4. **Error handling** - Handle both errors and empty results gracefully
@@ -61,5 +61,6 @@ Check your API usage in Profile Settings to monitor your credit consumption.
 ## Related Articles
 
 - [API documentation](/api-reference)
-- [Rate limits](/docs/knowledge-base/api/basics/rate-limits)
+- [API credit limits](/docs/knowledge-base/api/basics/credit-limits)
+- [API rate limits](/docs/knowledge-base/api/basics/rate-limits)
 - [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -1,0 +1,58 @@
+---
+title: "What is My API Credit Limit?"
+description: "Learn about Shovels API credit limits for paid plans, the free trial request system, and how to get higher limits for your needs."
+---
+
+**API credit limits apply to paid plans and control how many records you can retrieve.** Each record returned by the API counts against your credits. Contact sales for credit allocations tailored to your needs.
+
+<Info>
+**Credit limits vs. rate limits:** Credit limits track how many records you can consume based on your plan (a billing concept). Rate limits restrict how quickly you can make requests to protect system stability (a technical concept). This page covers credit limits. See [API Rate Limits](/docs/knowledge-base/api/basics/rate-limits) for rate limiting details.
+</Info>
+
+## Free Trial
+
+The API free trial provides **250 requests** with no time limit or credit card required. During the trial, each API call counts as **1 request regardless of how many records it returns**—so a search returning 100 permits still uses just 1 request.
+
+If you need more requests during your trial, contact [sales@shovels.ai](mailto:sales@shovels.ai) for an extension.
+
+## Paid Plan Credit Limits
+
+Paid plans include custom credit allocations based on your usage needs. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for plan details and pricing.
+
+<Info>
+For details on plan limits and pricing, [create an account](https://app.shovels.ai) to see current options or contact [sales@shovels.ai](mailto:sales@shovels.ai).
+</Info>
+
+## If You Hit Your Credit Limit
+
+When you exceed your credit limit, the API returns a **402 Payment Required** response. Contact [sales@shovels.ai](mailto:sales@shovels.ai) to increase your credit allocation.
+
+For full details on API usage policies, see the [API Introduction](/docs/shovels-api-introduction#acceptable-use-policy).
+
+## Understanding Your Credits
+
+### Records Per Call
+
+Search endpoints return up to **100 records per page** (default: 50) by setting the `size` parameter. Detail endpoints accept up to **50 IDs** per call. Each record returned counts against your credits—so a call returning 100 permits uses 100 credits.
+
+### Efficient Querying
+
+- Use search endpoints to get multiple records at once
+- Search responses include full detail payloads—no separate detail call needed
+- Use filters to get exactly the data you need
+
+## Tracking Your Usage
+
+Monitor your API usage in the **Profile Settings** section of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
+
+## Need Higher Credit Limits?
+
+Contact our team to discuss higher-tier plans:
+- Email: [sales@shovels.ai](mailto:sales@shovels.ai)
+- Phone: [1-800-511-7457](tel:+18005117457)
+
+## Related Articles
+
+- [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)
+- [How to access your API key](/docs/knowledge-base/api/basics/api-key-access)
+- [API Rate Limits](/docs/knowledge-base/api/basics/rate-limits)

--- a/docs/knowledge-base/api/basics/rate-limits.mdx
+++ b/docs/knowledge-base/api/basics/rate-limits.mdx
@@ -1,51 +1,33 @@
 ---
-title: "What is the Shovels API Rate Limit?"
-description: "The Shovels API free trial includes 250 credits. Learn about credit limits, maximizing efficiency, and getting higher limits for your needs."
+title: "What Are the Shovels API Rate Limits?"
+description: "Learn about the Shovels API rate limits that protect system stability and ensure fair access for all users."
 ---
 
-**The Shovels API free trial includes 250 credits with no time limit.** We don't enforce strict rate limits, but we monitor usage and may apply limits on an individual basis if needed. Contact sales for higher credit allocations.
-
-## Free Trial Limits
-
-The API free trial provides **250 credits** with no time limit or credit card required. If you need more credits during your trial, contact [sales@shovels.ai](mailto:sales@shovels.ai) for an extension.
-
-## Paid Plan Limits
-
-We don't enforce hard rate limits for paid plans, but we expect reasonable usage that respects our platform. We monitor usage and will reach out if we notice unusual patterns.
+**API rate limits restrict how quickly you can make requests** to ensure system stability and fair access for all users.
 
 <Info>
-For details on plan limits and pricing, [create an account](https://app.shovels.ai) to see current options or contact [sales@shovels.ai](mailto:sales@shovels.ai).
+**Rate limits vs. credit limits:** Rate limits restrict how quickly you can make requests (a technical concept). Credit limits track how many records you can consume based on your plan (a billing concept). This page covers rate limits. See [API Credit Limits](/docs/knowledge-base/api/basics/credit-limits) for credit limit details.
 </Info>
 
-## If You Hit Your Limit
+## Current Rate Limits
 
-If your API key appears to be rate-limited, contact [support@shovels.ai](mailto:support@shovels.ai) for clarification.
+We expect that you will respect our platform and avoid frivolous requests. We are constantly monitoring usage and will enforce rate limits on an individual basis as needed.
 
-For full details on API usage policies, see the [API Introduction](/docs/shovels-api-introduction#acceptable-use-policy).
+If you receive a **429 Too Many Requests** response, slow down your request rate and retry after a brief delay.
 
-## Understanding Your Credits
+## Best Practices
 
-### Records Per Call
+- **Space out requests** — avoid sending many requests simultaneously
+- **Implement backoff** — when you receive a 429 response, wait before retrying
+- **Use pagination efficiently** — fetch larger pages with the `size` parameter instead of many small requests
+- **Cache results locally** — store fetched data to avoid re-fetching the same records
 
-Search endpoints return up to **100 records per page** (default: 50) by setting the `size` parameter. Detail endpoints accept up to **50 IDs** per call. Each record returned counts against your credits—so a call returning 100 permits uses 100 credits.
+## If You Believe You're Being Rate Limited
 
-### Efficient Querying
-
-- Use search endpoints to get multiple records at once
-- Search responses include full detail payloads—no separate detail call needed
-- Use filters to get exactly the data you need
-
-## Tracking Your Usage
-
-Monitor your API usage in the **Profile Settings** section of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
-
-## Need Higher Limits?
-
-Contact our team to discuss higher-tier plans:
-- Email: [sales@shovels.ai](mailto:sales@shovels.ai)
-- Phone: [1-800-511-7457](tel:+18005117457)
+If you feel that your API key is being rate limited unexpectedly, please reach out to [support@shovels.ai](mailto:support@shovels.ai) for clarification.
 
 ## Related Articles
 
+- [API Credit Limits](/docs/knowledge-base/api/basics/credit-limits)
 - [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)
-- [How to access your API key](/docs/knowledge-base/api/basics/api-key-access)
+- [API Introduction](/docs/shovels-api-introduction)

--- a/docs/knowledge-base/api/basics/request-counts.mdx
+++ b/docs/knowledge-base/api/basics/request-counts.mdx
@@ -29,7 +29,7 @@ This applies to all endpoints:
 | `GET /v2/contractors?id=abc,def,ghi` | 3 contractors | 3 |
 
 <Info>
-The same credit system applies whether you're on the free trial or a paid plan.
+The credit system described above applies to **paid plans**. The free trial uses a simpler request-based system where each API call counts as 1 request, regardless of records returned.
 </Info>
 
 ## Managing Your Credits
@@ -49,11 +49,11 @@ curl -X GET "https://api.shovels.ai/v2/usage" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
-Response:
+Response (paid plan example):
 ```json
 {
-  "credits_used": 150,
-  "credit_limit": 250
+  "credits_used": 1500,
+  "credit_limit": 10000
 }
 ```
 
@@ -77,5 +77,5 @@ Credits operate on a **30-day rolling window**. Your usage resets based on when 
 
 ## Related Articles
 
-- [API rate limits](/docs/knowledge-base/api/basics/rate-limits)
+- [API credit limits](/docs/knowledge-base/api/basics/credit-limits)
 - [Permits per API call](/docs/knowledge-base/api/basics/permits-per-call)

--- a/docs/knowledge-base/api/contractors/employee-data.mdx
+++ b/docs/knowledge-base/api/contractors/employee-data.mdx
@@ -57,7 +57,7 @@ To process multiple contractors at scale:
 1. Obtain contractor IDs using the contractors search endpoints
 2. Iterate through each contractor ID
 3. Call the employees endpoint for each contractor
-4. Implement proper error handling and rate limiting
+4. Implement proper error handling and respect rate limits
 
 ### Targeting Decision Makers
 

--- a/docs/knowledge-base/edl/sample-records.mdx
+++ b/docs/knowledge-base/edl/sample-records.mdx
@@ -25,7 +25,7 @@ Reach out to customer support with your request:
 
 If you're considering using the API, you can also explore the data yourself with a free trial:
 - [Create a free account](https://app.shovels.ai)
-- Get 250 free API credits to test
+- Get 250 free API requests to test
 
 ## Example Requests
 

--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -1,9 +1,13 @@
 ---
 title: "What's Included in the Shovels Free Trial?"
-description: "The Shovels free trial includes permit and contractor search, 12 months of data, filters, and 250 API credits. No credit card required."
+description: "The Shovels free trial includes permit and contractor search, filters, and 250 API requests with full historical access. No credit card required."
 ---
 
-**The Shovels free trial includes full permit and contractor search, access to the last 12 months of data, all filters, and 250 API credits.** No credit card required. Paid plans unlock CSV downloads, 25+ years of historical data, and higher API credit limits.
+**The Shovels free trial includes full permit and contractor search, all filters, and 250 API requests.** No credit card required. Paid plans unlock CSV downloads and higher API credit limits.
+
+<Info>
+**Free trial vs. paid plans:** The free trial is request-based—each API call counts as 1 request, regardless of how many records it returns. Paid plans use a credit system where each record returned counts against your credits.
+</Info>
 
 ## Features Available in the Free Trial
 
@@ -13,7 +17,8 @@ Users can access the **permit** and **contractor** search functionality from the
 
 ### Data Availability
 
-The free trial includes access to the last 12 months of permit and contractor data. Paying customers get access to all historical Shovels data (on average, 25+ years).
+- **Shovels Online**: The free trial includes access to the last 12 months of permit and contractor data. Paid plans unlock all historical data (on average, 25+ years).
+- **API**: The free trial includes access to the full historical dataset—no date restrictions.
 
 ### Filters and Sorting
 

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -123,8 +123,11 @@ A flexible zoning classification for master-planned projects that allows develop
 
 ## R
 
-### Rate Limit / Credits
-The maximum number of records you can retrieve via the API. Free trials include 250 credits. Each record returned counts against your credits. Paid plans have custom limits—contact sales for details. See [API rate limits](/docs/knowledge-base/api/basics/rate-limits) for full information.
+### API Credit Limit
+The maximum number of records you can retrieve via the API based on your paid plan. Each record returned counts against your credits. Paid plans have custom limits—contact sales for details. Note: the free trial uses a request-based system (250 requests) rather than credits. See [API credit limits](/docs/knowledge-base/api/basics/credit-limits) for full information.
+
+### API Rate Limit
+A technical limit on how quickly you can make API requests. Rate limits protect system stability and ensure fair access for all users. If you exceed the rate limit, you'll receive a 429 Too Many Requests response. See [API rate limits](/docs/knowledge-base/api/basics/rate-limits) for details.
 
 ## S
 

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -24,7 +24,7 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
     Learn how to search for permits and contractors using our web application.
   </Card>
   <Card title="API Questions" icon="code" href="/docs/knowledge-base/api/basics/api-key-access">
-    Get help with API authentication, endpoints, rate limits, and troubleshooting.
+    Get help with API authentication, endpoints, credit limits, and troubleshooting.
   </Card>
   <Card title="Data & Coverage" icon="database" href="/docs/knowledge-base/data/permits/permit-tracking">
     Understand our permit and contractor data, coverage areas, and data quality.

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -14,7 +14,7 @@ Fast, concise answers to the most frequently asked questions about Shovels.
 Shovels Online and API pricing starts with a free tier. View current plans at [app.shovels.ai](https://app.shovels.ai). Enterprise Data License (EDL) pricing requires contacting [sales@shovels.ai](mailto:sales@shovels.ai).
 
 ### Is there a free trial?
-Yes. Free trials include access to the last 12 months of data and 250 API credits.
+Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.
 
 ### What's the difference between API and EDL?
 **API**: Best for lookups, integrations, and local lead lists.
@@ -24,8 +24,8 @@ Yes. Free trials include access to the last 12 months of data and 250 API credit
 
 ## API Basics
 
-### What is my API credit limit?
-The free trial includes 250 credits. Paid plans have custom limits—no hard rate limits are enforced, but we monitor usage. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for details.
+### What is my API limit?
+The free trial includes **250 requests** (each API call = 1 request, regardless of records returned). Paid plans use a credit system with custom credit limits where each record returned counts against your credits. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for details.
 
 ### How many records per API call?
 Search endpoints return up to 100 records per page (default: 50). Detail endpoints accept up to 50 IDs per call.

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -32,7 +32,7 @@ The use cases are endless, but the most common we see today are:
 To begin using the API, please contact our sales team at [sales@shovels.ai](mailto:sales@shovels.ai) or grab a [free API key](https://app.shovels.ai/create-account/).
 
 <Info>
-The free API key has a limited number of credits. If you hit the limit and need more, please reach out to [sales@shovels.ai](mailto:sales@shovels.ai) or call us at [1-800-511-7457](tel:+18005117457).
+The free API key includes 250 requests. If you use them all and need more, please reach out to [sales@shovels.ai](mailto:sales@shovels.ai) or call us at [1-800-511-7457](tel:+18005117457).
 </Info>
 
 ### API Key
@@ -43,9 +43,13 @@ For any API request, you'll need to include your API key. This is available in y
 
 We want you to be able to adequately test our API before making your decision. Completely separate from the Shovels Online web app trial, there is a free trial of the API key as well.
 
-API Key free trials include 250 credits with no time limit or credit card required. Each record returned by the API counts against your credits—for example, a search returning 100 permits uses 100 credits.
+API Key free trials include **250 free requests** with no time limit or credit card required. Each API call counts as 1 request, regardless of how many records are returned—so a search returning 100 permits still counts as just 1 request.
 
-If you exceed your credit limit and still need more, please reach out to [Sales](mailto:sales@shovels.ai) for an extension.
+<Info>
+**Free trial vs. paid plans:** The free trial is request-based (250 requests, each API call = 1 request). Paid plans use a credit system where each record returned counts against your credits. See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for details on the paid credit system.
+</Info>
+
+If you use all your free trial requests and need more, please reach out to [Sales](mailto:sales@shovels.ai) for an extension.
 
 ## Authentication
 
@@ -60,13 +64,13 @@ curl -X GET "https://api.shovels.ai/v2/meta/release" \
  -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
-If you have any issues with your API key, rate limits, or other authentication issues, please reach out to [Support](mailto:support@shovels.ai).
+If you have any issues with your API key, credit limits, or other authentication issues, please reach out to [Support](mailto:support@shovels.ai).
 
 ### Acceptable Use Policy
 
-We do not enforce any usage or rate limits at this time, but we expect that you will respect our platform and avoid frivolous requests. 
+We expect that you will respect our platform and avoid frivolous requests. We are constantly monitoring usage and will enforce rate limits on an individual basis as needed.
 
-However, we are constantly monitoring usage and will enforce rate limits on an individual basis as needed. If you feel that you're API key is rate limited, please reach out to [Support](mailto:support@shovels.ai) for clarification.
+If you feel that your API key is being rate limited, please reach out to [Support](mailto:support@shovels.ai) for clarification.
 
 ## API Details
 

--- a/docs/shovels-online-quickstart-guide.mdx
+++ b/docs/shovels-online-quickstart-guide.mdx
@@ -39,7 +39,7 @@ We also understand that you may need additional time to test and vet the system.
 
 #### Free Trial API Key
 
-All Free Trial accounts are also provided with an API Key, which has a separate, non-time based limit of 250 credits. Each record returned counts against your credits. Even if your Shovels Online free trial expires, you may continue to test the API with this key until you hit your credit limit. 
+All Free Trial accounts are also provided with an API Key, which has a separate, non-time based limit of **250 requests**. Each API call counts as 1 request, regardless of how many records are returned. Even if your Shovels Online free trial expires, you may continue to test the API with this key until you've used all your requests.
 
 To find your API key, click on your email address in the top right corner. From the account profile page, click the "API Key" tab to view your key, as well as some helpful resources for getting started. 
 

--- a/mint.json
+++ b/mint.json
@@ -176,6 +176,7 @@
                 "docs/knowledge-base/api/basics/api-key-access",
                 "docs/knowledge-base/api/basics/api-endpoints",
                 "docs/knowledge-base/api/basics/query-parameters",
+                "docs/knowledge-base/api/basics/credit-limits",
                 "docs/knowledge-base/api/basics/rate-limits",
                 "docs/knowledge-base/api/basics/request-counts",
                 "docs/knowledge-base/api/basics/permits-per-call",


### PR DESCRIPTION
## What

- **Separates "credit limit" (billing) from "rate limit" (technical)** across all documentation. Previously these were conflated, which would collide with the upcoming API rate limit system.
- **Renames `rate-limits.mdx` → `credit-limits.mdx`** for the billing/credit page; creates a new `rate-limits.mdx` for the technical rate limiting concept. Both pages cross-link with an Info callout explaining the distinction.
- **Clarifies the free trial uses 250 requests**, not credits. Each API call counts as 1 request regardless of how many records are returned (unlike paid plans where each record counts as 1 credit).
- **Clarifies the API free trial has full historical data access** — the 12-month restriction applies only to Shovels Online.
- Updates glossary, quick answers, navigation, and all cross-references across 14 files.

## Why

- We were wrong in our original understanding of how the credits will work during the trial. 
- "Rate limit" was an oversight / AI slop that we shouldn't have let into the original knowledge base transition from HubSpot. 