### PR TITLE
Add March 2026 release notes

### DIFF
--- a/.claude/skills/release-notes.md
+++ b/.claude/skills/release-notes.md
@@ -1,0 +1,142 @@
+# Release Notes Skill
+
+Automates the monthly release notes publishing process for Shovels documentation.
+
+## Usage
+
+Invoke with `/release-notes` to start the release notes workflow.
+
+## What This Skill Does
+
+1. **Calculates version and date:**
+   - Reads the latest release version from `release-notes/release-notes.mdx`
+   - Increments the patch number (e.g., V2.1.5 → V2.1.6)
+   - Uses current date in YYYY-MM-DD format
+
+2. **Prompts for content:**
+   - Asks user to paste the release notes email content
+
+3. **Parses and formats:**
+   - Extracts sections from the email content
+   - Organizes content into three tabs (Online, API, EDL)
+   - Applies bold-numbers-only formatting convention
+   - Adds proper Mintlify MDX structure
+
+4. **Inserts release:**
+   - Adds new release at the top of the file
+   - Maintains existing releases
+
+## Instructions
+
+When this skill is invoked:
+
+1. **Check git status and create branch:**
+   - Run `git status` to verify repository state
+   - Determine the current month and year for branch name
+   - Create branch name format: `{month}-{year}-release-notes` (e.g., "march-2026-release-notes")
+   - Create and checkout the new branch: `git checkout -b {branch-name}`
+
+2. **Read the current release notes file:**
+   ```
+   Read /Users/morganfriberg/Documents/GitHub/shovels-docs/release-notes/release-notes.mdx
+   ```
+
+3. **Determine next version:**
+   - Extract the latest version label (e.g., "V2.1.5")
+   - Increment the patch number to get the next version (e.g., "V2.1.6")
+   - Get current date in YYYY-MM-DD format
+
+4. **Ask the user to provide the email content:**
+   ```
+   Please paste the release notes email content below:
+   ```
+
+5. **Parse the email content:**
+   - Identify main sections (new features, Permits Dataset, Geocoding, API Enhancements, etc.)
+   - Extract metrics and numbers
+   - Organize by appropriate tab
+
+6. **Format according to conventions:**
+   - **Bold numbers only, not entire lines**
+   - Use consistent section headers with emojis
+   - Structure into three tabs:
+     - **Online:** New features + Permits + Geocoding
+     - **API:** New features + API Enhancements + Permits + Geocoding + No breaking changes note
+     - **EDL:** Permits + Geocoding
+
+7. **Apply MDX structure:**
+   ```mdx
+   <Update label="V2.1.X" description="YYYY-MM-DD">
+     <Tabs>
+       <Tab title="Online">
+         ### Introduction
+         [Introduction paragraph]
+
+         ### ✨ New
+         [New features]
+
+         ### 🏗️ Permits Dataset
+         [Permits content]
+
+         ### 📍 Geocoding Improvements
+         [Geocoding content]
+       </Tab>
+       <Tab title="API">
+         [Same structure with API-specific sections]
+
+         <Info>
+           ✅ **No breaking changes.** All existing integrations continue to work unchanged.
+         </Info>
+       </Tab>
+       <Tab title="EDL (Enterprise Data License)">
+         [Same structure with EDL-specific sections]
+       </Tab>
+     </Tabs>
+   </Update>
+   ```
+
+8. **Insert at the top of the file:**
+   - Place the new release immediately after the frontmatter and before the previous V2.1.X release
+   - Preserve all existing releases
+
+9. **Start local preview (optional):**
+   - Ask user if they want to preview locally with `mintlify dev`
+   - If yes, start the dev server in background
+
+10. **Commit the changes:**
+    - After user confirms the changes look good, offer to commit
+    - Suggested commit message format:
+      ```
+      Add [Month] [Year] release notes
+
+      Release V2.1.X with [brief summary of major updates].
+
+      Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+      ```
+    - Stage only the release-notes.mdx file
+    - Create the commit
+
+## Formatting Rules
+
+### Bold Numbers Only
+- ✅ `Permits filed in February 2026: **156K**`
+- ❌ `**Permits filed in February 2026:** **156K**`
+
+### Section Headers
+- `### 🏗️ Permits Dataset`
+- `### 📍 Geocoding Improvements`
+- `### ⚡ API Enhancements`
+- `### ✨ New`
+
+### Subsection Titles
+- `**New Permits Discovered**`
+- `**Additional Permits Geocoded**`
+
+### Common Patterns
+- Permit counts: `Permits filed in February 2026: **156K**`
+- Category growth: `Electrical Permits: **+388K** - Largest category growth this release`
+- Record counts: `**1.8M** Records`
+
+## Example Output Structure
+
+See `release-notes/release-notes.mdx` for examples of properly formatted releases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,3 +294,67 @@ code across route packages following three-level sharing convention.
 - Get the git branch name from the Linear issue to ensure automatic linking
 
 ---
+
+## Release Notes Process
+
+Monthly release notes are published to `release-notes/release-notes.mdx` following this workflow:
+
+### File Structure
+- Single file containing all releases in reverse chronological order (newest first)
+- Each release uses Mintlify's `<Update>` component
+- Version format: `V2.1.X` where X increments monthly
+- Date format: `YYYY-MM-DD`
+
+### Three-Tab Organization
+Every release must have three tabs with consistent structure:
+
+1. **Online Tab** - Shovels web platform updates
+   - New features and product announcements
+   - Permits dataset updates
+   - Geocoding improvements
+   - User-facing changes
+
+2. **API Tab** - REST API changes
+   - New endpoints and features
+   - API enhancements and improvements
+   - Permits dataset updates (same as Online)
+   - Geocoding improvements (same as Online)
+   - ALWAYS end with: `<Info>✅ **No breaking changes.** All existing integrations continue to work unchanged.</Info>` (unless there are breaking changes)
+
+3. **EDL (Enterprise Data License) Tab** - Enterprise data updates
+   - Permits dataset updates (same as Online/API)
+   - Geocoding improvements (same as Online/API)
+   - Data quality enhancements
+
+### Formatting Conventions
+**Bold numbers only, not entire lines:**
+- ✅ CORRECT: `Permits filed in February 2026: **156K**`
+- ❌ WRONG: `**Permits filed in February 2026:** **156K**`
+- ✅ CORRECT: `Electrical Permits: **+388K**`
+- ❌ WRONG: `**Electrical Permits:** **+388K**`
+- ✅ CORRECT: `**1.8M** Records`
+- ❌ WRONG: `**1.8M Records**`
+
+**Section headers:**
+- Use consistent emoji prefixes: `### 🏗️ Permits Dataset`, `### 📍 Geocoding Improvements`, `### ⚡ API Enhancements`
+- Use `**Bold**` for subsection titles like `**New Permits Discovered**`
+
+### Monthly Workflow
+1. User receives release notes email from HubSpot (currently manual copy/paste)
+2. Use `/release-notes` skill to automate the entire process
+3. Skill automatically:
+   - Creates a new branch (format: `{month}-{year}-release-notes`)
+   - Calculates next version number (reads current and increments)
+   - Prompts for email content
+   - Parses content into appropriate tabs
+   - Applies bold-numbers-only formatting
+   - Inserts at top of file
+   - Optionally starts local preview
+   - Commits changes with proper message
+
+### Version Numbering
+- Read the latest release version from the file
+- Increment the patch number (e.g., V2.1.5 → V2.1.6)
+- Use current date in YYYY-MM-DD format
+
+---

--- a/release-notes/release-notes.mdx
+++ b/release-notes/release-notes.mdx
@@ -4,6 +4,185 @@ icon: "code-merge"
 description: "Find out what the Engineering team has been up to across our entire platform, including general announcements, updates, and bugfixes."
 ---
 
+<Update label="V2.1.6" description="2026-03-02">
+  <Tabs>
+    <Tab title="Online">
+      ### Introduction
+
+      Big month. We're launching Shovels CLI — a new way to query permits, contractors, and addresses from the command line (or let your AI agent do it). On the data side, we added 1.8M new permits and geocoded another 1.4M records. Let's get into it.
+
+      ### ✨ New
+
+      **>_ Introducing Shovels CLI**
+
+      Your AI agent's gateway to U.S. construction data
+
+      One binary. Zero config. Pure JSON.
+
+      Search permits, query contractors, resolve addresses — all from your terminal
+
+      **Install in seconds**
+      ```bash
+      curl -LsSf https://shovels.ai/install.sh | sh
+      ```
+
+      **Built for automation**
+      - JSON-only output to stdout, errors to stderr
+      - Auto-pagination with `--limit all`
+      - Auto-retry with backoff on rate limits
+      - Help text optimized for LLM comprehension
+
+      Works on macOS, Linux, and Windows. Learn more at [shovels.ai/cli](https://shovels.ai/cli)
+
+      ### 🏗️ Permits Dataset
+
+      **New Permits Discovered**
+      - **1.8M** Records
+      - Expanding historical and current coverage across all jurisdictions
+
+      - Permits filed in February 2026: **156K**
+      - Permits filed year-to-date (2026): **462K**
+
+      **🧱 Permit Activity by Category**
+
+      - Electrical Permits: **+388K** - Largest category growth this release
+      - New construction permits: **+203K**
+      - HVAC permits: **+136K**
+      - Remodel permits: **+136K**
+      - Roofing permits: **+91K**
+      - Plumbing permits: **+71K**
+      - Solar permits: **+23K**
+      - Demolition permits: **+19K**
+      - ADU permits: **+12K**
+      - EV charger permits: **+2.2K**
+
+      ### 📍 Geocoding Improvements
+
+      **Additional Permits Geocoded**
+      - **+1.4M** Records
+      - Now with latitude and longitude coordinates for spatial analysis
+    </Tab>
+    <Tab title="API">
+      ### Introduction
+
+      Big month. We're launching Shovels CLI — a new way to query permits, contractors, and addresses from the command line (or let your AI agent do it). The API gained result counts on every paginated endpoint, an improved usage dashboard, and more accurate contractor metrics. On the data side, we added 1.8M new permits and geocoded another 1.4M records.
+
+      ### ✨ New
+
+      **>_ Introducing Shovels CLI**
+
+      Your AI agent's gateway to U.S. construction data
+
+      One binary. Zero config. Pure JSON.
+
+      Search permits, query contractors, resolve addresses — all from your terminal
+
+      **Install in seconds**
+      ```bash
+      curl -LsSf https://shovels.ai/install.sh | sh
+      ```
+
+      **Built for automation**
+      - JSON-only output to stdout, errors to stderr
+      - Auto-pagination with `--limit all`
+      - Auto-retry with backoff on rate limits
+      - Help text optimized for LLM comprehension
+
+      Works on macOS, Linux, and Windows. Learn more at [shovels.ai/cli](https://shovels.ai/cli)
+
+      ### ⚡ API Enhancements
+
+      **Result Counts on All Paginated Endpoints**
+      - **7** Endpoints · `include_count=true`
+      - Get total result counts before paginating
+      - Returns `{value, relation}` shape — exact count or "10,000+" for large sets
+
+      Supported on:
+      - `/v2/permits/search`
+      - `/v2/contractors/search`
+      - `/v2/contractors/{id}/permits`
+      - All **4** `geo_permits` endpoints
+
+      **Enhanced Usage Dashboard**
+
+      `GET /v2/usage` now includes:
+      - Daily breakdown
+      - `is_over_limit` flag
+      - `available_at` projection so you always know your credit status
+      - Over-limit users can still access usage data
+
+      **Improved Contractor Metrics Accuracy**
+
+      Fixed `permit_count` and `total_job_value` inflation for `tag=all` queries. Average metrics now use permit-count-weighted calculations for mathematical precision.
+
+      ### 🏗️ Permits Dataset
+
+      **New Permits Discovered**
+      - **1.8M** Records
+      - Expanding historical and current coverage across all jurisdictions
+
+      - Permits filed in February 2026: **156K**
+      - Permits filed year-to-date (2026): **462K**
+
+      **🧱 Permit Activity by Category**
+
+      - Electrical Permits: **+388K** - Largest category growth this release
+      - New construction permits: **+203K**
+      - HVAC permits: **+136K**
+      - Remodel permits: **+136K**
+      - Roofing permits: **+91K**
+      - Plumbing permits: **+71K**
+      - Solar permits: **+23K**
+      - Demolition permits: **+19K**
+      - ADU permits: **+12K**
+      - EV charger permits: **+2.2K**
+
+      ### 📍 Geocoding Improvements
+
+      **Additional Permits Geocoded**
+      - **+1.4M** Records
+      - Now with latitude and longitude coordinates for spatial analysis
+
+      <Info>
+        ✅ **No breaking changes.** All existing integrations continue to work unchanged.
+      </Info>
+    </Tab>
+    <Tab title="EDL (Enterprise Data License)">
+      ### Introduction
+
+      We added 1.8M new permits and geocoded another 1.4M records this month. Here's the full breakdown.
+
+      ### 🏗️ Permits Dataset
+
+      **New Permits Discovered**
+      - **1.8M** Records
+      - Expanding historical and current coverage across all jurisdictions
+
+      - Permits filed in February 2026: **156K**
+      - Permits filed year-to-date (2026): **462K**
+
+      **🧱 Permit Activity by Category**
+
+      - Electrical Permits: **+388K** - Largest category growth this release
+      - New construction permits: **+203K**
+      - HVAC permits: **+136K**
+      - Remodel permits: **+136K**
+      - Roofing permits: **+91K**
+      - Plumbing permits: **+71K**
+      - Solar permits: **+23K**
+      - Demolition permits: **+19K**
+      - ADU permits: **+12K**
+      - EV charger permits: **+2.2K**
+
+      ### 📍 Geocoding Improvements
+
+      **Additional Permits Geocoded**
+      - **+1.4M** Records
+      - Now with latitude and longitude coordinates for spatial analysis
+    </Tab>
+  </Tabs>
+</Update>
+
 <Update label="V2.1.5" description="2026-02-01">
   <Tabs>
     <Tab title="Online">


### PR DESCRIPTION
## Summary
- Add V2.1.6 release notes (March 2, 2026)
- Create `/release-notes` skill for automation
- Document release notes process in CLAUDE.md

## Release Highlights
- **Shovels CLI launch** - New command-line tool for permits and contractors data
- **1.8M new permits** discovered
- **1.4M permits geocoded**
- **API enhancements** - Result counts, enhanced usage dashboard, improved contractor metrics

## Automation Improvements
Created `/release-notes` skill that automates:
- Branch creation (date-based naming)
- Version calculation
- Content parsing and formatting
- MDX structure generation
- Commit creation

## Test Plan
- [x] Release notes formatted correctly (bold numbers only)
- [x] Three tabs populated (Online, API, EDL)
- [x] Local preview verified with `mintlify dev`
- [x] Skill documentation added to CLAUDE.md
- [ ] Review release notes content
- [ ] Verify skill works for next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)