### PR TITLE
Add CLI documentation and quickstart guide

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -15,7 +15,11 @@ If you have a question that isn't answered by our range of tutorials, how-to wal
   Explore Contractors and Permits at every geographical level, with filters for job type, building type, permit details, and more.
 </Card>
 
-<Card title="Shovels API" icon="terminal" horizontal="true" href="/api-reference">
+<Card title="Shovels CLI" icon="code" horizontal="true" href="/docs/shovels-cli-quickstart">
+  Query permits and contractors from your terminal or AI agent. One binary, JSON output, zero dependencies.
+</Card>
+
+<Card title="Shovels API" icon="plug" horizontal="true" href="/api-reference">
   Leverage our best-in-industry API, which is ready for direct product integration or programmatic data wrangling.
 </Card>
 

--- a/docs/knowledge-base/cli/authentication.mdx
+++ b/docs/knowledge-base/cli/authentication.mdx
@@ -1,0 +1,96 @@
+---
+title: "How Does CLI Authentication Work?"
+description: "The Shovels CLI authenticates using your API key, provided via environment variable or config file. Learn how to configure and manage your credentials."
+sidebarTitle: "Authentication"
+---
+
+**The CLI uses the same API key as the Shovels REST API.** You can provide it through an environment variable or a persistent config file.
+
+## Authentication Priority
+
+The CLI checks for your API key in this order (first match wins):
+
+1. `SHOVELS_API_KEY` environment variable
+2. Config file at `~/.config/shovels/config.yaml`
+
+## Option A: Environment Variable
+
+Set your API key for the current session:
+
+```bash
+export SHOVELS_API_KEY=your-api-key
+```
+
+This is useful for CI/CD pipelines, Docker containers, or temporary sessions.
+
+## Option B: Config File (Recommended)
+
+Save your API key persistently:
+
+```bash
+shovels config set api-key your-api-key
+```
+
+This creates or updates `~/.config/shovels/config.yaml`:
+
+```yaml
+api_key: your-api-key
+```
+
+The config file location follows the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), so it respects `$XDG_CONFIG_HOME` if set.
+
+## Verify Your Configuration
+
+```bash
+shovels config show
+```
+
+This displays your resolved configuration with the API key partially masked for security.
+
+## Additional Config Options
+
+The config file supports these settings:
+
+| Key | Description | Default |
+|---|---|---|
+| `api_key` | Your Shovels API key | (none) |
+| `base_url` | API base URL override | `https://api.shovels.ai/v2` |
+| `default_limit` | Default result limit | `50` |
+
+Set any option with the `config set` command:
+
+```bash
+shovels config set base-url https://api.shovels.ai/v2
+```
+
+## Authentication Errors
+
+If your API key is missing or invalid, the CLI exits with code `2` and prints a JSON error to stderr:
+
+```json
+{
+  "error": "API key is required. Set SHOVELS_API_KEY or run: shovels config set api-key YOUR_KEY",
+  "code": 2,
+  "error_type": "auth_error"
+}
+```
+
+<Info>
+Some commands don't require authentication: `version`, `config show`, and `usage`. Geographic search commands (`cities search`, `counties search`, etc.) and `tags list` are also credit-free but require a valid API key.
+</Info>
+
+## Getting an API Key
+
+If you don't have an API key yet:
+
+1. [Create a free Shovels account](https://app.shovels.ai/create-account/)
+2. Go to [Profile Settings](https://app.shovels.ai/profile-settings/)
+3. Copy your API key from the **API Key** field
+
+Free accounts include 250 requests to explore the platform.
+
+## Related Articles
+
+- [How to access your API key](/docs/knowledge-base/api/basics/api-key-access) — Find your key in the Shovels dashboard
+- [CLI installation](/docs/knowledge-base/cli/installation) — Install the CLI binary
+- [CLI error codes](/docs/knowledge-base/cli/error-codes) — Understanding exit codes and error types

--- a/docs/knowledge-base/cli/commands-overview.mdx
+++ b/docs/knowledge-base/cli/commands-overview.mdx
@@ -1,0 +1,189 @@
+---
+title: "What Commands Are Available in the CLI?"
+description: "A complete overview of Shovels CLI commands for searching permits, contractors, addresses, and geographic data from your terminal."
+sidebarTitle: "Commands Overview"
+---
+
+**The CLI organizes commands into groups: permits, contractors, addresses, geographic lookups, tags, usage, and config.** Every command outputs JSON to stdout and supports `--help` for detailed usage.
+
+## Command Reference
+
+### permits
+
+Search and retrieve building permit data.
+
+| Subcommand | Description | Key Flags |
+|---|---|---|
+| `permits search` | Search permits by location, date, tags, and filters | `--geo-id` (required), `--permit-from` (required), `--permit-to` (required) |
+| `permits get` | Retrieve 1-50 permits by ID | Positional IDs |
+
+**Example: Search permits**
+
+```bash
+shovels permits search \
+  --geo-id 92024 \
+  --permit-from 2024-01-01 \
+  --permit-to 2024-12-31 \
+  --tags solar \
+  --property-type residential \
+  --limit 50
+```
+
+### contractors
+
+Search contractors and access their permits, employees, and metrics.
+
+| Subcommand | Description | Key Flags |
+|---|---|---|
+| `contractors search` | Search contractors by location and filters | `--geo-id` (required) |
+| `contractors get` | Retrieve 1-50 contractors by ID | Positional IDs |
+| `contractors permits` | List permits filed by a contractor | Contractor ID (positional) |
+| `contractors employees` | List employees of a contractor | Contractor ID (positional) |
+| `contractors metrics` | Monthly performance metrics | `--metric-from`, `--metric-to`, `--property-type`, `--tag` (all required) |
+
+**Example: Find electrical contractors in Austin**
+
+```bash
+shovels contractors search \
+  --geo-id 78701 \
+  --permit-from 2024-01-01 \
+  --permit-to 2024-12-31 \
+  --tags electrical \
+  --min-permits 10
+```
+
+<Info>
+Contractor search supports state, county, city, jurisdiction, and ZIP code geo_ids, but **not** address-level geo_ids. Use `permits search` for address-level queries.
+</Info>
+
+### addresses
+
+Search for addresses to resolve geo_ids.
+
+```bash
+shovels addresses search -q "1600 Pennsylvania Ave"
+```
+
+Returns matching addresses with their `geo_id`, formatted name, and coordinates.
+
+### cities, counties, jurisdictions
+
+Resolve geographic names to geo_ids for use in search commands.
+
+```bash
+shovels cities search -q "Miami Beach"
+shovels counties search -q "Los Angeles"
+shovels jurisdictions search -q "San Francisco"
+```
+
+### tags
+
+List available permit tags (work type classifications).
+
+```bash
+shovels tags list
+```
+
+Returns tags like `solar`, `hvac`, `roofing`, `electrical`, `pool_spa`, `new_dwelling`, `kitchen_remodel`, and more. Use these values with the `--tags` flag in search commands.
+
+### usage
+
+Check your API credit usage and limits.
+
+```bash
+shovels usage
+```
+
+### config
+
+Manage persistent CLI settings.
+
+```bash
+shovels config set api-key your-key  # Save API key
+shovels config show                   # Display current config
+```
+
+### version
+
+Print CLI version, git commit, and build date.
+
+```bash
+shovels version
+```
+
+## Common Search Filters
+
+These flags are available on `permits search` and `contractors search`:
+
+### Tag Filters
+
+```bash
+--tags solar                 # Include permits tagged "solar"
+--tags solar,roofing         # Include solar OR roofing
+--tags -electrical           # Exclude electrical permits
+```
+
+Tags support a `-` prefix for exclusion. Mix includes and excludes as needed.
+
+### Property Filters
+
+```bash
+--property-type residential
+--min-market-value 500000
+--min-building-area 2000
+--min-lot-size 5000
+--min-story-count 2
+--min-unit-count 4
+```
+
+### Permit Filters
+
+```bash
+--status final               # final, active, in_review, inactive
+--min-job-value 100000
+--min-fees 500
+--min-approval-duration 30   # days
+--min-construction-duration 90
+--min-inspection-pr 80       # pass rate percentage
+--has-contractor             # only permits with a linked contractor
+-q "solar panel"             # text search in permit description
+```
+
+### Contractor Filters (contractor search only)
+
+```bash
+--contractor-name "Smith"
+--contractor-license "ABC123"
+--classification general,electrical
+--min-permits 50
+--min-job-value 1000000
+```
+
+## Global Flags
+
+These flags apply to all commands:
+
+| Flag | Description | Default |
+|---|---|---|
+| `--limit` | Max records to return (1-100000 or `all`) | `50` |
+| `--max-records` | Cap when using `--limit all` | `10000` |
+| `--include-count` | Include total result count in response | `false` |
+| `--base-url` | Override API endpoint | Config or default |
+| `--no-retry` | Disable automatic retry on rate limits | `false` |
+| `--timeout` | Per-request timeout (Go duration format) | `30s` |
+
+## Getting Help
+
+Every command supports `--help`:
+
+```bash
+shovels --help                  # Top-level help
+shovels permits --help          # Permits group help
+shovels permits search --help   # Detailed search flags and examples
+```
+
+## Related Articles
+
+- [CLI quickstart guide](/docs/shovels-cli-quickstart) — First query in under a minute
+- [Output format and pagination](/docs/knowledge-base/cli/output-and-pagination) — Understanding JSON responses
+- [Scripting and AI agents](/docs/knowledge-base/cli/scripting-and-agents) — Composing CLI commands into workflows

--- a/docs/knowledge-base/cli/error-codes.mdx
+++ b/docs/knowledge-base/cli/error-codes.mdx
@@ -1,0 +1,141 @@
+---
+title: "What Do CLI Exit Codes and Errors Mean?"
+description: "The Shovels CLI uses structured exit codes and JSON error messages to make troubleshooting straightforward for developers, scripts, and AI agents."
+sidebarTitle: "Error Codes"
+---
+
+**The CLI uses distinct exit codes for each error category.** Scripts and AI agents can branch on the exit code without parsing the error message.
+
+## Exit Codes
+
+| Code | Type | Meaning |
+|---|---|---|
+| `0` | Success | Command completed successfully |
+| `1` | Client error | Invalid flags, validation failure, or bad request |
+| `2` | Auth error | Missing or invalid API key |
+| `3` | Rate limited | Too many requests (HTTP 429) |
+| `4` | Credits exhausted | API credit limit reached (HTTP 402) |
+| `5` | Server/network error | Server failure or connectivity issue |
+
+## Error Response Format
+
+Errors are written to **stderr** as structured JSON:
+
+```json
+{
+  "error": "descriptive message explaining what went wrong",
+  "code": 2,
+  "error_type": "auth_error"
+}
+```
+
+The `error_type` field provides a machine-readable classification:
+
+| error_type | Exit Code | Common Causes |
+|---|---|---|
+| `client_error` | 1 | Missing required flags, invalid flag values |
+| `validation_error` | 1 | Invalid date range, bad geo_id format (HTTP 422) |
+| `auth_error` | 2 | No API key configured, or key is invalid (HTTP 401) |
+| `rate_limited` | 3 | Too many concurrent requests (HTTP 429) |
+| `credit_exhausted` | 4 | Monthly credit limit reached (HTTP 402) |
+| `server_error` | 5 | Shovels API returned a 5xx error |
+| `network_error` | 5 | DNS failure, timeout, or connection refused |
+
+## Common Errors and Solutions
+
+### Exit 1: Client Error
+
+**Missing required flags:**
+
+```
+$ shovels permits search --geo-id 92024
+Error: required flags "permit-from", "permit-to" not set
+```
+
+Fix: Add the required `--permit-from` and `--permit-to` flags.
+
+**Invalid date range:**
+
+```json
+{
+  "error": "permit_from must be before permit_to",
+  "code": 1,
+  "error_type": "validation_error"
+}
+```
+
+Fix: Ensure your `--permit-from` date is earlier than `--permit-to`. Use `YYYY-MM-DD` format.
+
+### Exit 2: Auth Error
+
+```json
+{
+  "error": "API key is required. Set SHOVELS_API_KEY or run: shovels config set api-key YOUR_KEY",
+  "code": 2,
+  "error_type": "auth_error"
+}
+```
+
+Fix: Set your API key via environment variable or config file. See [CLI authentication](/docs/knowledge-base/cli/authentication).
+
+### Exit 3: Rate Limited
+
+```json
+{
+  "error": "rate limited after 3 retries",
+  "code": 3,
+  "error_type": "rate_limited"
+}
+```
+
+The CLI automatically retries rate-limited requests with exponential backoff and jitter (up to 3 retries). If this error appears, wait a moment and try again, or contact support if it persists.
+
+<Info>
+Use `--no-retry` to disable automatic retry if you want to handle rate limits yourself in a script.
+</Info>
+
+### Exit 4: Credits Exhausted
+
+```json
+{
+  "error": "credit limit reached",
+  "code": 4,
+  "error_type": "credit_exhausted"
+}
+```
+
+Your monthly credit allowance is used up. Check your usage with `shovels usage` and contact [sales@shovels.ai](mailto:sales@shovels.ai) to increase your limit.
+
+### Exit 5: Server or Network Error
+
+```json
+{
+  "error": "connection timeout after 30s",
+  "code": 5,
+  "error_type": "network_error"
+}
+```
+
+Check your internet connection. If the Shovels API is down, try again later. You can adjust the timeout with `--timeout 60s`.
+
+## Using Exit Codes in Scripts
+
+```bash
+shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  > results.json 2> error.json
+
+case $? in
+  0) echo "Success: $(jq '.meta.count' results.json) records" ;;
+  2) echo "Auth failed — check your API key" ;;
+  3) echo "Rate limited — retrying in 60s"; sleep 60 ;;
+  4) echo "Out of credits — contact sales" ;;
+  *) echo "Error: $(cat error.json)" ;;
+esac
+```
+
+## Related Articles
+
+- [CLI authentication](/docs/knowledge-base/cli/authentication) — Configure your API key
+- [API error handling](/docs/knowledge-base/api/errors/error-handling) — REST API error codes
+- [API credit limits](/docs/knowledge-base/api/basics/credit-limits) — Understanding credit consumption

--- a/docs/knowledge-base/cli/installation.mdx
+++ b/docs/knowledge-base/cli/installation.mdx
@@ -1,0 +1,93 @@
+---
+title: "How Do I Install the Shovels CLI?"
+description: "Install the Shovels CLI on macOS, Linux, or Windows using the install script or by downloading binaries directly from GitHub Releases."
+sidebarTitle: "Installation"
+---
+
+**The fastest way to install is the one-line install script.** It detects your platform, downloads the correct binary, and verifies the SHA256 checksum.
+
+```bash
+curl -LsSf https://shovels.ai/install.sh | sh
+```
+
+The binary installs to `~/.shovels/bin` by default.
+
+## Supported Platforms
+
+| OS | Architecture | Binary |
+|---|---|---|
+| macOS | Apple Silicon (arm64) | `shovels-darwin-arm64` |
+| macOS | Intel (amd64) | `shovels-darwin-amd64` |
+| Linux | arm64 | `shovels-linux-arm64` |
+| Linux | amd64 | `shovels-linux-amd64` |
+| Windows | amd64 | `shovels-windows-amd64.exe` |
+
+## Install Script Options
+
+The install script supports environment variables for customization:
+
+| Variable | Description | Default |
+|---|---|---|
+| `SHOVELS_VERSION` | Pin to a specific release version | Latest |
+| `SHOVELS_INSTALL_DIR` | Custom installation directory | `~/.shovels/bin` |
+
+Example with custom options:
+
+```bash
+SHOVELS_VERSION=0.1.0 SHOVELS_INSTALL_DIR=/usr/local/bin \
+  curl -LsSf https://shovels.ai/install.sh | sh
+```
+
+## Manual Download
+
+Download binaries directly from [GitHub Releases](https://github.com/ShovelsAI/shovels-cli/releases/latest). Each release includes SHA256 checksums for verification.
+
+```bash
+# Example: download and verify on macOS arm64
+curl -LO https://github.com/ShovelsAI/shovels-cli/releases/latest/download/shovels-darwin-arm64
+curl -LO https://github.com/ShovelsAI/shovels-cli/releases/latest/download/checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+chmod +x shovels-darwin-arm64
+mv shovels-darwin-arm64 /usr/local/bin/shovels
+```
+
+## Add to PATH
+
+If the CLI isn't found after installation, add the install directory to your `PATH`:
+
+```bash
+# Add to ~/.zshrc (macOS) or ~/.bashrc (Linux)
+export PATH="$HOME/.shovels/bin:$PATH"
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc  # or ~/.bashrc
+```
+
+## Verify Installation
+
+```bash
+shovels version
+```
+
+This prints the CLI version, git commit hash, and build date.
+
+## Updating
+
+Re-run the install script to get the latest version:
+
+```bash
+curl -LsSf https://shovels.ai/install.sh | sh
+```
+
+<Info>
+The CLI is a single static binary with no runtime dependencies. Updating simply replaces the binary file.
+</Info>
+
+## Related Articles
+
+- [CLI quickstart guide](/docs/shovels-cli-quickstart) — Get up and running in under a minute
+- [CLI authentication](/docs/knowledge-base/cli/authentication) — Configure your API key
+- [How to access your API key](/docs/knowledge-base/api/basics/api-key-access) — Get an API key from your Shovels account

--- a/docs/knowledge-base/cli/output-and-pagination.mdx
+++ b/docs/knowledge-base/cli/output-and-pagination.mdx
@@ -1,0 +1,149 @@
+---
+title: "How Does CLI Output and Pagination Work?"
+description: "The Shovels CLI outputs JSON to stdout with automatic pagination. Learn about response formats, the --limit flag, and credit tracking."
+sidebarTitle: "Output & Pagination"
+---
+
+**All CLI output is valid JSON written to stdout. Errors go to stderr.** This makes the CLI safe to pipe into `jq`, scripts, or other tools without worrying about mixed output.
+
+## Response Format
+
+### Paginated Responses (search commands)
+
+```json
+{
+  "data": [
+    { "id": "...", "description": "...", "status": "final" }
+  ],
+  "meta": {
+    "count": 50,
+    "has_more": true,
+    "credits_used": 1,
+    "credits_remaining": 9999
+  }
+}
+```
+
+### Single Object Responses (get commands with one ID)
+
+```json
+{
+  "data": {
+    "id": "...",
+    "name": "...",
+    "permit_count": 42
+  },
+  "meta": {
+    "credits_used": 1,
+    "credits_remaining": 9999
+  }
+}
+```
+
+### Batch Responses (get commands with multiple IDs)
+
+```json
+{
+  "data": [
+    { "id": "ABC", "name": "..." },
+    { "id": "DEF", "name": "..." }
+  ],
+  "meta": {
+    "count": 2,
+    "missing": ["UNKNOWN_ID"],
+    "credits_used": 1,
+    "credits_remaining": 9999
+  }
+}
+```
+
+The `missing` array lists any IDs that weren't found.
+
+## Pagination with --limit
+
+The `--limit` flag controls how many records to return. The CLI handles cursor-based pagination internally — you never need to manage cursors yourself.
+
+| Value | Behavior |
+|---|---|
+| `--limit 50` (default) | Return up to 50 records |
+| `--limit 500` | Return up to 500 records |
+| `--limit all` | Fetch all records (capped by `--max-records`) |
+
+```bash
+# Get first 10 results
+shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --limit 10
+
+# Get all results (up to 10,000 by default)
+shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --limit all
+```
+
+### --max-records
+
+When using `--limit all`, the `--max-records` flag sets the upper bound (default: 10,000, maximum: 100,000):
+
+```bash
+shovels permits search --geo-id CA \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags solar --limit all --max-records 50000
+```
+
+### --include-count
+
+Add `--include-count` to include the total number of matching records in the response:
+
+```bash
+shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags solar --include-count --limit 1
+```
+
+```json
+{
+  "data": ["..."],
+  "meta": {
+    "count": 1,
+    "has_more": true,
+    "total_count": {
+      "value": 581,
+      "relation": "eq"
+    },
+    "credits_used": 1,
+    "credits_remaining": 9999
+  }
+}
+```
+
+<Info>
+Total counts are exact up to 10,000 (`"relation": "eq"`). Above 10,000, the count is approximate (`"relation": "gte"` means "at least this many").
+</Info>
+
+## Credit Tracking
+
+Every response includes `credits_used` and `credits_remaining` in the `meta` object. This lets you monitor usage without making a separate API call.
+
+To check your overall credit status:
+
+```bash
+shovels usage
+```
+
+## Data Types in Responses
+
+| Field Type | Format | Example |
+|---|---|---|
+| Dates | ISO 8601 (`YYYY-MM-DD`) | `"2024-06-15"` |
+| Money amounts | Integer cents | `150000` = $1,500.00 |
+| Ratings | Float 0-5 | `4.2` |
+| Pass rates | Integer 0-100 | `85` (percentage) |
+| Coordinates | `[lat, lng]` float array | `[32.87, -117.25]` |
+| geo_ids | Base64-encoded string | `"Q2l0eXxGTHxNaWFtaQ"` |
+
+## Related Articles
+
+- [CLI commands overview](/docs/knowledge-base/cli/commands-overview) — Full list of commands and flags
+- [CLI error codes](/docs/knowledge-base/cli/error-codes) — Understanding error responses
+- [Scripting and AI agents](/docs/knowledge-base/cli/scripting-and-agents) — Piping CLI output into workflows

--- a/docs/knowledge-base/cli/scripting-and-agents.mdx
+++ b/docs/knowledge-base/cli/scripting-and-agents.mdx
@@ -1,0 +1,171 @@
+---
+title: "How Do I Use the CLI in Scripts and AI Agents?"
+description: "The Shovels CLI is designed for composability. Learn how to pipe output with jq, build shell scripts, automate with cron, and integrate with AI coding agents."
+sidebarTitle: "Scripting & AI Agents"
+---
+
+**The CLI follows Unix conventions: JSON to stdout, errors to stderr, meaningful exit codes.** This makes it composable with `jq`, shell scripts, cron jobs, and AI coding agents like Claude Code, Cursor, and Codex.
+
+## Piping with jq
+
+Since all output is valid JSON, use `jq` to extract, filter, and transform results:
+
+```bash
+# Count total solar permits in a ZIP code
+shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags solar --include-count --limit 1 \
+  | jq '.meta.total_count.value'
+
+# Extract just contractor names and phone numbers
+shovels contractors search --geo-id 78701 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags electrical --limit 100 \
+  | jq '.data[] | {name, phone: .primary_phone}'
+
+# Export to CSV
+shovels contractors search --geo-id CA \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags solar --limit all \
+  | jq -r '.data[] | [.name, .primary_phone, .permit_count] | @csv' \
+  > solar_contractors_ca.csv
+```
+
+## Shell Scripts
+
+### Resolve a city name and search permits
+
+```bash
+#!/bin/bash
+# find-permits.sh — Search permits in a city by name
+
+city_name="$1"
+tag="$2"
+year="$3"
+
+# Resolve city to geo_id
+geo_id=$(shovels cities search -q "$city_name" \
+  | jq -r '.data[0].geo_id')
+
+if [ -z "$geo_id" ] || [ "$geo_id" = "null" ]; then
+  echo "City not found: $city_name" >&2
+  exit 1
+fi
+
+# Search permits
+shovels permits search \
+  --geo-id "$geo_id" \
+  --permit-from "${year}-01-01" \
+  --permit-to "${year}-12-31" \
+  --tags "$tag" \
+  --limit all
+```
+
+Usage:
+
+```bash
+./find-permits.sh "Miami Beach" roofing 2024 | jq '.meta.count'
+```
+
+### Batch lookup contractors by ID
+
+```bash
+#!/bin/bash
+# Given a file with one contractor ID per line, fetch details
+
+while IFS= read -r id; do
+  shovels contractors get "$id" | jq '.data'
+done < contractor_ids.txt
+```
+
+## Cron Jobs
+
+Monitor permit activity on a weekly schedule:
+
+```bash
+# crontab -e
+# Run every Monday at 8 AM
+0 8 * * MON /path/to/weekly-permits.sh
+```
+
+```bash
+#!/bin/bash
+# weekly-permits.sh — Count permits filed in the last 7 days
+
+from_date=$(date -v-7d +%Y-%m-%d)  # macOS
+to_date=$(date +%Y-%m-%d)
+
+count=$(shovels permits search \
+  --geo-id 94110 \
+  --permit-from "$from_date" \
+  --permit-to "$to_date" \
+  --include-count --limit 1 \
+  | jq '.meta.total_count.value')
+
+echo "$count permits filed in 94110 this week"
+```
+
+## AI Agent Integration
+
+The CLI is built with an agent-first design. AI coding agents (Claude Code, Cursor, Codex, or custom agents) can:
+
+1. **Read `--help`** to understand available commands and flags
+2. **Run commands** and parse the JSON output
+3. **Branch on exit codes** to handle errors programmatically
+4. **Chain commands** to build multi-step research workflows
+
+### How an AI agent uses the CLI
+
+```bash
+# Step 1: Agent reads the help to understand the tool
+shovels permits search --help
+
+# Step 2: Agent constructs and runs a query
+shovels permits search --geo-id 94110 \
+  --permit-from 2024-06-01 --permit-to 2024-12-31 \
+  --tags roofing --property-type residential --limit 20
+
+# Step 3: Agent parses the JSON response
+# Step 4: Agent follows up with related queries
+shovels contractors get CONTRACTOR_ID_FROM_RESULTS
+```
+
+<Info>
+The CLI help text is written to be clear and specific so that an LLM can construct the correct command on the first attempt. No human-oriented decorations (colors, spinners, progress bars) interfere with parsing.
+</Info>
+
+### Why CLI over MCP for agents?
+
+The CLI avoids common MCP pain points:
+
+- **No context bloat** — the agent only reads what it requests
+- **No credential juggling** — one API key in the environment
+- **No host lock-in** — works with any agent that can run shell commands
+- **No protocol overhead** — plain JSON in, plain JSON out
+
+## Error Handling in Scripts
+
+```bash
+result=$(shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 2>/tmp/shovels-err.json)
+
+if [ $? -ne 0 ]; then
+  error_type=$(jq -r '.error_type' /tmp/shovels-err.json)
+  case "$error_type" in
+    auth_error) echo "Check your API key" ;;
+    rate_limited) echo "Rate limited — waiting..." && sleep 60 ;;
+    credit_exhausted) echo "Out of credits" ;;
+    *) echo "Error: $(jq -r '.error' /tmp/shovels-err.json)" ;;
+  esac
+  exit 1
+fi
+
+echo "$result" | jq '.data | length'
+```
+
+## Related Articles
+
+- [CLI commands overview](/docs/knowledge-base/cli/commands-overview) — Full list of commands and flags
+- [CLI output and pagination](/docs/knowledge-base/cli/output-and-pagination) — Understanding JSON responses
+- [CLI error codes](/docs/knowledge-base/cli/error-codes) — Exit codes reference
+- [Automate API calls](/docs/knowledge-base/api/basics/automate-calls) — Automating with the REST API directly

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -20,10 +20,13 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
   <Card title="Getting Started" icon="rocket" href="/docs/knowledge-base/getting-started/free-trial-guide">
     New to Shovels? Learn about free trials, pricing, and what makes us different.
   </Card>
+  <Card title="Shovels CLI" icon="code" href="/docs/knowledge-base/cli/installation">
+    Install and use the command-line tool for permits, contractors, and scripting.
+  </Card>
   <Card title="Shovels Online" icon="browser" href="/docs/knowledge-base/shovels-online/how-it-works">
     Learn how to search for permits and contractors using our web application.
   </Card>
-  <Card title="API Questions" icon="code" href="/docs/knowledge-base/api/basics/api-key-access">
+  <Card title="API Questions" icon="plug" href="/docs/knowledge-base/api/basics/api-key-access">
     Get help with API authentication, endpoints, credit limits, and troubleshooting.
   </Card>
   <Card title="Data & Coverage" icon="database" href="/docs/knowledge-base/data/permits/permit-tracking">
@@ -43,6 +46,11 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 - [What makes Shovels different?](/docs/knowledge-base/getting-started/key-differentiators)
 - [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
 - [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+
+### Using the CLI
+- [How do I install the CLI?](/docs/knowledge-base/cli/installation)
+- [What commands are available?](/docs/knowledge-base/cli/commands-overview)
+- [How do I use the CLI with AI agents?](/docs/knowledge-base/cli/scripting-and-agents)
 
 ### Using the API
 - [How do I access my API key?](/docs/knowledge-base/api/basics/api-key-access)

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Introducing the Shovels API"
 description: "Comprehensive guide to the Shovels REST API, including authentication, pagination, error handling, and getting started information."
-icon: "terminal"
+icon: "plug"
 ---
 
 The Shovels REST API makes it easy for technology developers in the property, climate, and construction industries to access detailed information about building permits, contractors and construction activity. Our API is designed to be intuitive and fast. We look forward to seeing what you build with it: [let us know](https://docs.google.com/forms/d/e/1FAIpQLSfs5Z6NZyPdnRpL96bMduH95OhfFZgLz9Hkc0-Y7pukUxSLxQ/viewform) and we'll check it out!

--- a/docs/shovels-cli-quickstart.mdx
+++ b/docs/shovels-cli-quickstart.mdx
@@ -1,0 +1,192 @@
+---
+title: Shovels CLI Quickstart Guide
+icon: code
+description: Install the Shovels CLI, configure your API key, and run your first permit search in under a minute.
+---
+
+**The Shovels CLI is a single-binary command-line tool for querying U.S. building permit and contractor data.** It outputs JSON to stdout, handles pagination automatically, and retries on rate limits. No runtime dependencies required.
+
+<Info>
+**CLI vs. API vs. Online:** The CLI wraps the same Shovels REST API but handles auth headers, cursor pagination, rate-limit retries, and credit tracking for you. Use it from your terminal, in shell scripts, or from AI agents.
+</Info>
+
+## Install
+
+Run the install script to download the latest release:
+
+```bash
+curl -LsSf https://shovels.ai/install.sh | sh
+```
+
+The script detects your OS and architecture, downloads the correct binary from GitHub Releases, verifies the SHA256 checksum, and installs to `~/.shovels/bin`.
+
+<Tip>
+Add `~/.shovels/bin` to your `PATH` if the installer doesn't do it automatically. For most shells, add `export PATH="$HOME/.shovels/bin:$PATH"` to your shell profile.
+</Tip>
+
+Verify the installation:
+
+```bash
+shovels version
+```
+
+## Configure Your API Key
+
+You need a Shovels API key. If you don't have one, [create a free account](https://app.shovels.ai/create-account/) to get a key with 250 free requests.
+
+There are two ways to provide your API key:
+
+### Option A: Environment variable
+
+```bash
+export SHOVELS_API_KEY=your-api-key
+```
+
+### Option B: Config file (persistent)
+
+```bash
+shovels config set api-key your-api-key
+```
+
+This saves your key to `~/.config/shovels/config.yaml` so you don't need to export it every session.
+
+Confirm your config is set:
+
+```bash
+shovels config show
+```
+
+## Run Your First Query
+
+Search for solar permits in Encinitas, CA (ZIP 92024) from 2024:
+
+```bash
+shovels permits search \
+  --geo-id 92024 \
+  --permit-from 2024-01-01 \
+  --permit-to 2024-12-31 \
+  --tags solar \
+  --limit 5
+```
+
+You'll see JSON output like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "...",
+      "description": "INSTALL ROOF MOUNTED SOLAR PV SYSTEM...",
+      "status": "final",
+      "tags": ["solar"],
+      "address": {
+        "street": "123 Main St",
+        "city": "Encinitas",
+        "state": "CA",
+        "zip_code": "92024"
+      }
+    }
+  ],
+  "meta": {
+    "count": 5,
+    "has_more": true,
+    "credits_used": 1,
+    "credits_remaining": 249
+  }
+}
+```
+
+Every response includes a `meta` object with credit tracking so you always know your usage.
+
+## Understanding geo_id
+
+Most search commands require a `--geo-id` flag. A geo_id can be:
+
+- **A ZIP code** — Use it directly (e.g., `92024`)
+- **A state** — Use the 2-letter code (e.g., `CA`)
+- **A city, county, or jurisdiction** — Use the base64-encoded ID from a search
+
+To find a geo_id for a city:
+
+```bash
+shovels cities search -q "Miami Beach"
+```
+
+```json
+{
+  "data": [
+    {
+      "geo_id": "Q2l0eXxGTHxNaWFtaSBCZWFjaA",
+      "name": "Miami Beach, FL"
+    }
+  ]
+}
+```
+
+Use that `geo_id` in subsequent searches:
+
+```bash
+shovels permits search \
+  --geo-id Q2l0eXxGTHxNaWFtaSBCZWFjaA \
+  --permit-from 2024-01-01 \
+  --permit-to 2024-12-31 \
+  --tags roofing
+```
+
+## Explore More Commands
+
+The CLI covers permits, contractors, addresses, and geographic lookups:
+
+```bash
+# Search contractors by location and specialty
+shovels contractors search \
+  --geo-id 78701 \
+  --permit-from 2024-01-01 \
+  --permit-to 2024-12-31 \
+  --tags electrical
+
+# Look up a specific contractor's permits
+shovels contractors permits CONTRACTOR_ID
+
+# Search for an address
+shovels addresses search -q "1600 Pennsylvania Ave"
+
+# Check your API credit usage
+shovels usage
+
+# List available permit tags
+shovels tags list
+```
+
+Every command has built-in help:
+
+```bash
+shovels permits search --help
+```
+
+## Pipe It
+
+The CLI outputs JSON to stdout, so it works with `jq` and other Unix tools:
+
+```bash
+# Count solar permits in a ZIP code
+shovels permits search --geo-id 92024 \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags solar --include-count --limit 1 \
+  | jq '.meta.total_count.value'
+
+# Export contractor names and permit counts to CSV
+shovels contractors search --geo-id CA \
+  --permit-from 2024-01-01 --permit-to 2024-12-31 \
+  --tags solar --limit 100 \
+  | jq -r '.data[] | [.name, .permit_count] | @csv' \
+  > solar_contractors.csv
+```
+
+## Next Steps
+
+- [CLI installation options](/docs/knowledge-base/cli/installation) — Platform-specific details and version pinning
+- [CLI commands overview](/docs/knowledge-base/cli/commands-overview) — Full list of commands and flags
+- [Output format and pagination](/docs/knowledge-base/cli/output-and-pagination) — Understanding responses and `--limit all`
+- [Scripting and AI agents](/docs/knowledge-base/cli/scripting-and-agents) — Composing the CLI into workflows
+- [CLI error codes](/docs/knowledge-base/cli/error-codes) — Exit codes and troubleshooting

--- a/docs/tutorial-cli-contractor-pipeline.mdx
+++ b/docs/tutorial-cli-contractor-pipeline.mdx
@@ -1,0 +1,143 @@
+---
+title: Building a Contractor Pipeline with the CLI
+icon: terminal
+description: This tutorial walks through using the Shovels CLI to find top contractors in a market, pull their details, and export to CSV — all from your terminal.
+---
+
+The Shovels CLI makes it easy to go from a broad market search to a targeted contractor list in a few commands. In this tutorial, we'll find the top solar contractors in a California ZIP code, inspect their permit history, and export the results to CSV.
+
+This is a common workflow for sales teams, market researchers, and AI agents building lead lists.
+
+## <Icon icon="cauldron" size="30px"/> Step-by-Step Recipe
+
+<Steps>
+    <Step title="Set Up the CLI" titleSize="h3" stepNumber={0}>
+        If you haven't already, install the CLI and configure your API key:
+
+        ```bash
+        curl -LsSf https://shovels.ai/install.sh | sh
+        shovels config set api-key YOUR_API_KEY
+        ```
+
+        Verify it works:
+
+        ```bash
+        shovels version
+        ```
+
+        For detailed setup instructions, see the [CLI Quickstart Guide](/docs/shovels-cli-quickstart).
+    </Step>
+
+    <Step title="Find Your Target Market" titleSize="h3" stepNumber={1}>
+        If you know your ZIP code, you can use it directly as a `--geo-id`. If you need to find a city or county geo_id, search for it:
+
+        ```bash
+        shovels cities search -q "Encinitas"
+        ```
+
+        ```json
+        {
+          "data": [
+            {
+              "geo_id": "Q2l0eXxDQXxFbmNpbml0YXM",
+              "name": "Encinitas, CA"
+            }
+          ]
+        }
+        ```
+
+        For this tutorial, we'll use ZIP code `92024` (Encinitas, CA).
+    </Step>
+
+    <Step title="Search for Contractors" titleSize="h3" stepNumber={2}>
+        Search for solar contractors active in 2024:
+
+        ```bash
+        shovels contractors search \
+          --geo-id 92024 \
+          --permit-from 2024-01-01 \
+          --permit-to 2024-12-31 \
+          --tags solar \
+          --limit 20
+        ```
+
+        This returns up to 20 contractors with their names, contact info, permit counts, and ratings.
+
+        <Tip>
+        Add `--include-count` with `--limit 1` to see the total number of matching contractors before fetching the full list.
+        </Tip>
+    </Step>
+
+    <Step title="Inspect a Contractor's Permits" titleSize="h3" stepNumber={3}>
+        Pick a contractor ID from the results and view their permit history:
+
+        ```bash
+        shovels contractors permits CONTRACTOR_ID --limit 10
+        ```
+
+        This returns individual permits with descriptions, dates, job values, and addresses.
+
+        To see monthly performance metrics:
+
+        ```bash
+        shovels contractors metrics CONTRACTOR_ID \
+          --metric-from 2024-01-01 \
+          --metric-to 2024-12-31 \
+          --property-type residential \
+          --tag solar
+        ```
+    </Step>
+
+    <Step title="Export to CSV" titleSize="h3" stepNumber={4}>
+        Use `jq` to transform the JSON output into CSV:
+
+        ```bash
+        shovels contractors search \
+          --geo-id 92024 \
+          --permit-from 2024-01-01 \
+          --permit-to 2024-12-31 \
+          --tags solar \
+          --limit all \
+          | jq -r '["Name","Phone","Email","Permits","Avg Job Value"],
+                   (.data[] | [.name, .primary_phone, .primary_email,
+                    .permit_count, .avg_job_value]) | @csv' \
+          > solar_contractors_encinitas.csv
+        ```
+
+        This creates a CSV with headers, ready for a spreadsheet or CRM import.
+    </Step>
+
+    <Step title="Expand to a Broader Area (Optional)" titleSize="h3" stepNumber={5}>
+        Scale up by searching at the state level:
+
+        ```bash
+        shovels contractors search \
+          --geo-id CA \
+          --permit-from 2024-01-01 \
+          --permit-to 2024-12-31 \
+          --tags solar \
+          --min-permits 10 \
+          --limit all \
+          | jq -r '["Name","Phone","Permits"],
+                   (.data[] | [.name, .primary_phone, .permit_count]) | @csv' \
+          > solar_contractors_ca.csv
+        ```
+
+        Use `--min-permits` to filter for contractors with a track record.
+    </Step>
+</Steps>
+
+## Adjusting Your Search
+
+If your results are too broad or too narrow, here are some adjustments:
+
+- **Too many results**: Add `--min-permits`, `--min-job-value`, or narrow the `--geo-id` to a smaller area
+- **Too few results**: Expand the date range, use a broader geo_id (county or state), or remove tag filters
+- **Wrong specialty**: Use `shovels tags list` to see all available tags and pick the right one
+- **Need specific contractors**: Add `--contractor-name` or `--contractor-license` to filter by known details
+
+## Additional Help
+
+If you run into issues, check the [CLI error codes](/docs/knowledge-base/cli/error-codes) guide or reach out to [support@shovels.ai](mailto:support@shovels.ai).
+
+Happy Digging!

--- a/mint.json
+++ b/mint.json
@@ -101,12 +101,24 @@
       ]
     },
     {
+      "group": "Shovels CLI",
+      "pages": [
+        "docs/shovels-cli-quickstart"
+      ]
+    },
+    {
       "group": "Tutorials",
       "pages": [
         {
           "group": "Shovels Online",
           "pages": [
             "docs/tutorial-online-contractor-search"
+          ]
+        },
+        {
+          "group": "Shovels CLI",
+          "pages": [
+            "docs/tutorial-cli-contractor-pipeline"
           ]
         },
         {
@@ -216,6 +228,17 @@
                 "docs/knowledge-base/api/errors/422-error"
               ]
             }
+          ]
+        },
+        {
+          "group": "Shovels CLI",
+          "pages": [
+            "docs/knowledge-base/cli/installation",
+            "docs/knowledge-base/cli/authentication",
+            "docs/knowledge-base/cli/commands-overview",
+            "docs/knowledge-base/cli/output-and-pagination",
+            "docs/knowledge-base/cli/error-codes",
+            "docs/knowledge-base/cli/scripting-and-agents"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- Add CLI quickstart guide with install, auth, first query walkthrough
- Add 6 knowledge base articles: installation, authentication, commands overview, output/pagination, error codes, scripting & AI agents
- Add tutorial: "Building a Contractor Pipeline with the CLI"
- Add CLI card to introduction page and knowledge base index
- Differentiate CLI (`code` icon) and API (`plug` icon) across site