### PR TITLE
Add CLI documentation to knowledge base glossary and quick answers

### DIFF
--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -31,6 +31,9 @@ A unique identifier assigned by Shovels to each contractor. Contractor IDs are d
 ### Contractor Group ID
 An identifier linking multiple contractors that operate under the same parent organization. For example, regional branches of a national company share the same group ID.
 
+### CLI Config File
+A YAML configuration file at `~/.config/shovels/config.yaml` that stores persistent CLI settings like your API key and default preferences. Created with `shovels config set`.
+
 ## D
 
 ### Decision (Shovels Decision)
@@ -46,6 +49,9 @@ The process of identifying and consolidating duplicate records. Shovels deduplic
 
 ### EDL (Enterprise Data License)
 Shovels' bulk data product for enterprise customers. EDL delivers complete datasets to data warehouses like Snowflake, BigQuery, or Databricks, with more fields than the API and monthly refresh cycles.
+
+### Exit Code (CLI)
+A numeric status code returned when a CLI command completes. Used by scripts and AI agents to determine success (0) or error type (1-5): client error, auth error, rate limited, credits exhausted, or server error.
 
 ## F
 
@@ -87,6 +93,11 @@ The date when a permit was approved and issued by the jurisdiction, allowing con
 
 ### Jurisdiction
 The geographic area governed by a specific AHJ. Shovels covers approximately 2,000 jurisdictions representing about 85% of the US population.
+
+## L
+
+### --limit all
+A CLI flag that fetches all available records instead of the default 50-record limit. Automatically handles pagination with an upper bound set by `--max-records` (default: 10,000, max: 100,000).
 
 ## N
 
@@ -136,6 +147,9 @@ An older industry classification system used to categorize businesses. More wide
 
 ### Special Use Permit
 Permission granted by a municipality to conduct a specific activity that isn't automatically allowed in a zone but may be approved with conditions. Also called conditional use permits in some jurisdictions. Special use permits often precede specific business or development activity at a known location.
+
+### Shovels CLI
+A single-binary command-line tool for querying U.S. building permit and contractor data. Outputs JSON to stdout and handles pagination, rate limits, and credit tracking automatically. No runtime dependencies required.
 
 ### Shovels Online
 The web-based application for searching and downloading permit and contractor data. Access at [app.shovels.ai](https://app.shovels.ai).

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -49,7 +49,9 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 
 ### Using the CLI
 - [How do I install the CLI?](/docs/knowledge-base/cli/installation)
+- [How do I configure my API key?](/docs/knowledge-base/cli/authentication)
 - [What commands are available?](/docs/knowledge-base/cli/commands-overview)
+- [How do I get all results?](/docs/knowledge-base/cli/output-and-pagination)
 - [How do I use the CLI with AI agents?](/docs/knowledge-base/cli/scripting-and-agents)
 
 ### Using the API

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -41,6 +41,31 @@ A required parameter is missing. Most commonly, you need to resolve an address t
 
 ---
 
+## CLI (Command Line)
+
+### How do I install the CLI?
+Run the install script: `curl -LsSf https://shovels.ai/install.sh | sh`. The script downloads the correct binary for your platform and installs it to `~/.shovels/bin`. Add to PATH if needed.
+
+### How do I configure my API key?
+Two options: (1) Environment variable: `export SHOVELS_API_KEY=your-key`, or (2) Config file (persistent): `shovels config set api-key your-key`. Verify with `shovels config show`.
+
+### What's the difference between CLI and API?
+The CLI wraps the Shovels REST API but handles authentication headers, cursor pagination, rate-limit retries, and credit tracking automatically. Use the CLI from terminals, shell scripts, or AI agents. Use the API directly for application integrations.
+
+### How do I get all results instead of just 50?
+Use `--limit all`. The CLI automatically handles pagination and fetches up to 10,000 records by default (configurable with `--max-records`).
+
+### What commands are available?
+Main commands: `permits search`, `permits get`, `contractors search`, `contractors get`, `contractors permits`, `contractors employees`, `contractors metrics`, `addresses search`, `cities search`, `tags list`, `usage`, `config`. Run `shovels --help` for full list.
+
+### Can I use the CLI with scripts and AI agents?
+Yes. The CLI outputs JSON to stdout and errors to stderr with meaningful exit codes (0=success, 1=client error, 2=auth error, 3=rate limited, 4=credits exhausted, 5=server error). Perfect for piping to `jq` or scripting.
+
+### What does exit code 2 mean?
+Exit code 2 is an authentication error—your API key is missing or invalid. Set it with `shovels config set api-key YOUR_KEY` or via the `SHOVELS_API_KEY` environment variable.
+
+---
+
 ## Data Coverage
 
 ### What areas does Shovels cover?


### PR DESCRIPTION
## Summary

This PR adds CLI-specific content to the knowledge base glossary and quick answers sections to improve discoverability of CLI documentation. The changes include:

**Glossary additions (4 new terms):**
- **Shovels CLI** - Definition of the command-line tool
- **CLI Config File** - Explanation of `~/.config/shovels/config.yaml`
- **Exit Code (CLI)** - Numeric status codes for error handling
- **--limit all** - Flag for fetching all records with pagination

**Quick Answers - New CLI section (7 questions):**
- How do I install the CLI?
- How do I configure my API key?
- What's the difference between CLI and API?
- How do I get all results instead of just 50?
- What commands are available?
- Can I use the CLI with scripts and AI agents?
- What does exit code 2 mean?

**Knowledge Base Index updates:**
- Added "How do I configure my API key?" to popular questions
- Added "How do I get all results?" to popular questions

## Why we are making this change

The CLI documentation was recently added to the knowledge base with comprehensive detail pages, but key information was missing from the high-traffic glossary and quick answers pages. This creates a discoverability problem where users:

1. **Can't find CLI terms in the glossary** when looking up concepts like "exit codes" or "config files"
2. **Don't see CLI in quick answers** - there's no fast-reference section for common CLI questions alongside API and Online sections
3. **Miss CLI on the KB landing page** - only 3 questions were featured vs. more comprehensive coverage for API/Online

By adding CLI content to these central knowledge base pages, we make it easier for users to find CLI information without having to know exactly which detailed page to visit. This is especially important for new CLI users who are exploring the platform and need quick answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)