### PR TITLE
Add 5 KB articles from Notion tracker (Charlie AI, billing, data usage, few results)

### DIFF
--- a/docs/knowledge-base/company/contact-information.mdx
+++ b/docs/knowledge-base/company/contact-information.mdx
@@ -33,3 +33,9 @@ Shovels' official mailing address:
 ## Community
 
 Join our [Discord community](https://discord.gg/Nypja3cKDx) for discussions and support.
+
+## Related Articles
+
+- [Refund policy](/docs/knowledge-base/company/refund-policy)
+- [What can I do with Shovels data?](/docs/knowledge-base/company/data-usage-terms)
+- [How do I cancel my subscription?](/docs/knowledge-base/shovels-online/cancel-subscription)

--- a/docs/knowledge-base/company/data-usage-terms.mdx
+++ b/docs/knowledge-base/company/data-usage-terms.mdx
@@ -1,0 +1,43 @@
+---
+title: "What Can and Can't I Do With Shovels Data?"
+description: "Shovels data is licensed for internal business use: research, prospecting, lead generation, and product integration. Uploading to ad platforms, reselling, or sharing externally is not permitted."
+---
+
+**Shovels data is licensed for your internal business use.** You can use it for internal research, prospecting, lead generation, building it into your own product (API customers), exporting and storing it internally, sharing with colleagues, and contacting contractors or property owners directly. You **cannot** upload it to ad platforms for audience targeting, resell or redistribute it, share it externally without written permission, or use it to build a competing data product.
+
+## What You Can Do
+
+- Use permit and contractor data for internal research, prospecting, and lead generation
+- Build the data into your own product or application (API customers)
+- Export and store data internally for business analysis
+- Share data with colleagues within your organization
+- Use the data to contact contractors or property owners directly
+
+## What You Cannot Do
+
+- **Upload Shovels data to ad platforms** (Facebook, Google, LinkedIn, etc.) for audience targeting or lookalike campaigns
+- **Resell or redistribute** the data to third parties
+- **Share data externally** outside your organization without written permission
+- **Use the data to build a competing data product**
+
+<Warning>
+**Example:** Using a list of addresses from Shovels to create a Facebook Custom Audience or Google Customer Match list is not permitted under our Terms of Service.
+</Warning>
+
+## Why These Restrictions Exist
+
+Shovels sources its data through direct relationships with local governments and jurisdictions. Our licensing agreements require that we limit how the data is used and distributed. These restrictions protect both Shovels and our customers.
+
+## Questions About Your Use Case?
+
+If you're unsure whether your intended use is permitted, email [support@shovels.ai](mailto:support@shovels.ai) before proceeding. We're happy to clarify.
+
+## Full Terms of Service
+
+For the complete terms, visit [shovels.ai/terms](https://shovels.ai/terms).
+
+## Related Articles
+
+- [Contact information](/docs/knowledge-base/company/contact-information)
+- [Where does Shovels data come from?](/docs/knowledge-base/data/quality/data-sources)
+- [Refund policy](/docs/knowledge-base/company/refund-policy)

--- a/docs/knowledge-base/company/refund-policy.mdx
+++ b/docs/knowledge-base/company/refund-policy.mdx
@@ -1,0 +1,47 @@
+---
+title: "What Is Shovels' Refund Policy?"
+description: "Shovels reviews refund requests case-by-case. Email support@shovels.ai within 30 days of the charge with your account email, charge details, and reason. Approved refunds appear within 5–10 business days."
+---
+
+**Refund requests are reviewed case-by-case. Contact [support@shovels.ai](mailto:support@shovels.ai) within 30 days of the charge with your account email, charge amount and date, and a brief description.** The billing team responds within 2 business days, and approved refunds typically appear on your original payment method within 5–10 business days.
+
+## Eligibility
+
+Refund requests are considered case-by-case. We'll do our best to make it right if:
+
+- The data you received was materially different from what was described
+- You experienced a technical issue that prevented you from accessing the product
+- You contacted us within **30 days** of your charge
+
+## How to Request a Refund
+
+Email [support@shovels.ai](mailto:support@shovels.ai) with:
+
+- Your account email
+- The charge amount and approximate date
+- A brief description of what didn't meet your expectations
+
+Our billing team reviews your request and responds within **2 business days**.
+
+## What to Expect
+
+- Approved refunds are returned to the original payment method
+- Refunds typically appear within **5–10 business days** depending on your bank
+- Partial refunds may be issued for partial usage periods
+
+## Things We Can't Refund
+
+- Charges older than 30 days (exceptions considered for extenuating circumstances)
+- Credits or API usage already consumed
+- Enterprise Data License deliveries that have already been fulfilled
+
+## Questions?
+
+- **Email:** [support@shovels.ai](mailto:support@shovels.ai)
+- **Phone:** [1-800-511-7457](tel:+18005117457)
+
+## Related Articles
+
+- [How do I cancel my subscription?](/docs/knowledge-base/shovels-online/cancel-subscription)
+- [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
+- [Contact information](/docs/knowledge-base/company/contact-information)

--- a/docs/knowledge-base/data/geographic/coverage-areas.mdx
+++ b/docs/knowledge-base/data/geographic/coverage-areas.mdx
@@ -63,4 +63,5 @@ For a detailed explanation, see [Permit Availability](/docs/foundations-understa
 
 - [Understanding jurisdictions](/docs/knowledge-base/data/geographic/jurisdictions)
 - [Data refresh frequency](/docs/knowledge-base/data/quality/refresh-frequency)
+- [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)
 - [Permit Availability explained](/docs/foundations-understanding-permits)

--- a/docs/knowledge-base/data/quality/few-results.mdx
+++ b/docs/knowledge-base/data/quality/few-results.mdx
@@ -1,0 +1,61 @@
+---
+title: "Why Am I Getting So Few Results?"
+description: "Common reasons Shovels searches return fewer results than expected: limited jurisdiction coverage, narrow filters, recent permits not yet indexed, or limited digitization."
+---
+
+**If your search is returning fewer results than expected, the most common causes are limited jurisdiction coverage, filters that are too narrow, recent permits not yet indexed (1–2 month lag), or limited digitization in the local jurisdiction.** Most have easy workarounds.
+
+## 1. The Area Has Limited Coverage
+
+Shovels covers approximately **2,000 jurisdictions** representing about **85% of the US population**. Some cities and counties are not yet in our system, and coverage density varies by region.
+
+**What to do:**
+- Check the [Coverage Dashboard](https://www.shovels.ai/coverage) to see what's available in your area
+- Try broadening your search to county or state level
+- Coverage expands monthly — an area with thin data today may improve in coming months
+
+## 2. Your Filters Are Too Narrow
+
+Shovels Online uses **AND** logic, so the more filters you apply, the smaller your result set. A search for a specific permit type, in a specific city, within a specific date range can return very few results even in well-covered areas.
+
+**What to do:**
+- Remove one filter at a time and see where results increase
+- Broaden the date range
+- Search at zip code or county level instead of city
+- Try a permit type tag (e.g. `solar`) instead of a keyword
+
+<Info>
+The search system does not account for typos or terminology variations. Contractors may use different abbreviations (like "SFR" instead of "single family residence"), so try alternatives.
+</Info>
+
+## 3. Recent Permits May Not Be Indexed Yet
+
+Shovels data updates monthly, with a typical **1–2 month lag** between when a permit is issued and when it appears in Shovels. Permits filed in the last 4–8 weeks may not be visible yet.
+
+**What to do:**
+- If you're looking for very recent activity, check back next month
+- For time-sensitive needs, contact [support@shovels.ai](mailto:support@shovels.ai) and we can check the pipeline
+
+## 4. The Jurisdiction Uses Limited Digitization
+
+Even within covered jurisdictions, some local governments have incomplete or inconsistently formatted permit records. This can result in sparse data for specific cities or permit types.
+
+**What to do:**
+- Email [support@shovels.ai](mailto:support@shovels.ai) with the specific jurisdiction — we can investigate and flag it for improvement
+
+## Still Not Finding What You Need?
+
+Email [support@shovels.ai](mailto:support@shovels.ai) with:
+- The specific area or jurisdiction you're searching
+- The permit type or contractor you're looking for
+- What results you expected vs. what you got
+
+We'll investigate and let you know what's happening.
+
+## Related Articles
+
+- [What areas does Shovels cover?](/docs/knowledge-base/data/geographic/coverage-areas)
+- [How often is data refreshed?](/docs/knowledge-base/data/quality/refresh-frequency)
+- [Understanding jurisdictions](/docs/knowledge-base/data/geographic/jurisdictions)
+- [Search functionality](/docs/knowledge-base/shovels-online/search-functionality)
+- [Filters and sorting](/docs/knowledge-base/shovels-online/filters-and-sorting)

--- a/docs/knowledge-base/data/quality/refresh-frequency.mdx
+++ b/docs/knowledge-base/data/quality/refresh-frequency.mdx
@@ -41,3 +41,4 @@ If you cache IDs and encounter not-found responses, use other record attributes 
 
 - [EDL monthly deliveries](/docs/knowledge-base/edl/monthly-deliveries)
 - [Data sources](/docs/knowledge-base/data/quality/data-sources)
+- [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)

--- a/docs/knowledge-base/getting-started/charlie-ai.mdx
+++ b/docs/knowledge-base/getting-started/charlie-ai.mdx
@@ -1,0 +1,47 @@
+---
+title: "What Is Charlie AI?"
+description: "Charlie is Shovels' AI research agent at charlie.shovels.ai. Ask permit data questions in plain English and get instant answers — no filters, downloads, or code required."
+---
+
+**Charlie is Shovels' AI research agent.** Ask questions about permit data in plain English at [charlie.shovels.ai](https://charlie.shovels.ai) and get instant answers — no filters, no downloads, no code required. Charlie is built on the full Shovels dataset and uses your Shovels API credits.
+
+## What Charlie Can Do
+
+Charlie can answer complex, natural-language questions that would otherwise take minutes to build manually in the web app.
+
+**Example questions:**
+- "Find all solar permits filed in Connecticut by Freedom Forever in the last 12 months"
+- "Which contractors pulled the most HVAC permits in Austin, TX last year?"
+- "How many ADU permits were issued in Los Angeles County in 2024?"
+- "Show me roofing contractors in Phoenix with more than 50 permits filed"
+- "What's the average job value for new construction permits in Denver?"
+
+## When to Use Charlie
+
+Charlie is ideal when you want a quick answer without building a search from scratch. Use it when:
+
+- You have a specific research question (contractor, geography, permit type)
+- You want to verify data before pulling a full export
+- You're not sure what filters to use in the web app
+- You want to explore the data conversationally
+
+<Info>
+For bulk exports or recurring data pulls, [Shovels Online](/docs/knowledge-base/shovels-online/how-it-works) or the [API](/docs/knowledge-base/api/basics/api-key-access) will serve you better.
+</Info>
+
+## Credits & Access
+
+Charlie uses your Shovels API credits and is available to any user with an active API plan. Free trial users receive **250 requests** to get started.
+
+See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for details on how requests are counted.
+
+## Getting Started
+
+Visit [charlie.shovels.ai](https://charlie.shovels.ai) and sign in with your Shovels account.
+
+## Related Articles
+
+- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
+- [How do I access my API key?](/docs/knowledge-base/api/basics/api-key-access)
+- [How Shovels Online works](/docs/knowledge-base/shovels-online/how-it-works)

--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -48,5 +48,6 @@ The free trial provides a great way to evaluate Shovels' data quality and covera
 ## Next Steps
 
 - [Learn how Shovels Online works](/docs/knowledge-base/shovels-online/how-it-works)
+- [Try Charlie AI](/docs/knowledge-base/getting-started/charlie-ai) — ask permit questions in plain English
 - [Understand our pricing structure](/docs/knowledge-base/getting-started/pricing-structure)
 - Contact [sales@shovels.ai](mailto:sales@shovels.ai) for API access or enterprise products

--- a/docs/knowledge-base/getting-started/pricing-structure.mdx
+++ b/docs/knowledge-base/getting-started/pricing-structure.mdx
@@ -32,3 +32,9 @@ For Enterprise Data options, please contact [sales@shovels.ai](mailto:sales@shov
 For questions about pricing or to discuss your specific needs:
 - Email: [sales@shovels.ai](mailto:sales@shovels.ai)
 - Phone: [1-800-511-7457](tel:+18005117457)
+
+## Related Articles
+
+- [How do I cancel my subscription?](/docs/knowledge-base/shovels-online/cancel-subscription)
+- [Refund policy](/docs/knowledge-base/company/refund-policy)
+- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -25,6 +25,9 @@ A zoning change applied to a larger geographic area, often initiated by municipa
 
 ## C
 
+### Charlie (Charlie AI)
+Shovels' AI research agent at [charlie.shovels.ai](https://charlie.shovels.ai). Charlie answers natural-language questions about permit and contractor data using the full Shovels dataset. Charlie consumes your Shovels API credits.
+
 ### Contractor ID
 A unique identifier assigned by Shovels to each contractor. Contractor IDs are deduplicated within each state, meaning the same contractor operating in multiple states will have separate IDs per state.
 

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -46,6 +46,7 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 - [What makes Shovels different?](/docs/knowledge-base/getting-started/key-differentiators)
 - [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
 - [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [What is Charlie AI?](/docs/knowledge-base/getting-started/charlie-ai)
 
 ### Using the CLI
 - [How do I install the CLI?](/docs/knowledge-base/cli/installation)
@@ -65,6 +66,12 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 - [How are permits tracked?](/docs/knowledge-base/data/permits/permit-lifecycle)
 - [What do permit statuses mean?](/docs/knowledge-base/data/permits/permit-statuses)
 - [Where does your data come from?](/docs/knowledge-base/data/quality/data-sources)
+- [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)
+
+### Account & Billing
+- [How do I cancel my subscription?](/docs/knowledge-base/shovels-online/cancel-subscription)
+- [What is Shovels' refund policy?](/docs/knowledge-base/company/refund-policy)
+- [What can I do with Shovels data?](/docs/knowledge-base/company/data-usage-terms)
 
 ### Enterprise Data (EDL)
 - [When should I use EDL vs API?](/docs/knowledge-base/edl/overview)

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -16,9 +16,25 @@ Shovels Online and API pricing starts with a free tier. View current plans at [a
 ### Is there a free trial?
 Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.
 
+### How do I cancel my subscription?
+Log in at [app.shovels.ai](https://app.shovels.ai) → Account Settings → Manage Subscription → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
+
+### What is Shovels' refund policy?
+Refunds are reviewed case-by-case for charges within the last 30 days. Email [support@shovels.ai](mailto:support@shovels.ai) with your account email and charge details. See [Refund Policy](/docs/knowledge-base/company/refund-policy).
+
+### What can I do with Shovels data?
+Internal business use: research, prospecting, lead generation, and product integration. You cannot upload it to ad platforms (Facebook, Google, etc.), resell, or redistribute it. See [Data usage terms](/docs/knowledge-base/company/data-usage-terms).
+
 ### What's the difference between API and EDL?
 **API**: Best for lookups, integrations, and local lead lists.
 **EDL**: Best for bulk data analysis. Full dataset delivered to your data warehouse.
+
+---
+
+## Charlie AI
+
+### What is Charlie AI?
+Charlie is Shovels' AI research agent at [charlie.shovels.ai](https://charlie.shovels.ai). Ask permit data questions in plain English and get instant answers — no filters, downloads, or code required. Uses your API credits. See [What is Charlie AI?](/docs/knowledge-base/getting-started/charlie-ai).
 
 ---
 
@@ -76,6 +92,9 @@ At least 2010 for all jurisdictions. Many jurisdictions have data going back fur
 
 ### How often is data updated?
 Monthly. We add 5-10 million new records and 1-5 million status updates each month.
+
+### Why am I getting so few results?
+Common causes: limited jurisdiction coverage, filters too narrow, recent permits not yet indexed (1–2 month lag), or limited digitization in the local jurisdiction. See [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results).
 
 ### Where does Shovels get its data?
 Directly from jurisdictions through relationships with local governments, online permitting portals, and public records requests. We don't purchase data from other vendors.

--- a/docs/knowledge-base/shovels-online/cancel-subscription.mdx
+++ b/docs/knowledge-base/shovels-online/cancel-subscription.mdx
@@ -1,0 +1,44 @@
+---
+title: "How Do I Cancel My Shovels Subscription?"
+description: "Cancel your Shovels subscription anytime from Account Settings → Manage Subscription in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
+---
+
+**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai](https://app.shovels.ai), open Account Settings, click Manage Subscription, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
+
+## How to Cancel
+
+1. Log in at [app.shovels.ai](https://app.shovels.ai)
+2. Go to **Account Settings**
+3. Click **Manage Subscription**
+4. You'll be taken to the Stripe billing portal
+5. Select **Cancel Subscription** and confirm
+
+## What Happens After You Cancel
+
+- You retain full access until your billing period ends
+- You will not be charged again after cancellation
+- Your data and account remain accessible until the period ends, then revert to free tier
+- Your API key remains active on the free tier (**250 requests**)
+
+## Cancelling an Enterprise Data License (EDL)
+
+EDL agreements are managed separately. To cancel or modify an EDL, contact [sales@shovels.ai](mailto:sales@shovels.ai) directly.
+
+## Want to Pause Instead?
+
+If you're not ready to fully cancel, email [support@shovels.ai](mailto:support@shovels.ai) — we may be able to help with a pause or adjusted plan depending on your situation.
+
+## Refunds
+
+See our [Refund Policy](/docs/knowledge-base/company/refund-policy) for refund eligibility and how to request one.
+
+## Questions?
+
+- **Email:** [support@shovels.ai](mailto:support@shovels.ai)
+- **Phone:** [1-800-511-7457](tel:+18005117457)
+
+## Related Articles
+
+- [Refund policy](/docs/knowledge-base/company/refund-policy)
+- [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
+- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)

--- a/docs/knowledge-base/shovels-online/how-it-works.mdx
+++ b/docs/knowledge-base/shovels-online/how-it-works.mdx
@@ -72,3 +72,5 @@ Paying customers can download search results as CSV files. This feature is not a
 - [Free trial guide](/docs/knowledge-base/getting-started/free-trial-guide)
 - [Search functionality](/docs/knowledge-base/shovels-online/search-functionality)
 - [Filters and sorting](/docs/knowledge-base/shovels-online/filters-and-sorting)
+- [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)
+- [How do I cancel my subscription?](/docs/knowledge-base/shovels-online/cancel-subscription)

--- a/mint.json
+++ b/mint.json
@@ -176,7 +176,8 @@
           "pages": [
             "docs/knowledge-base/getting-started/free-trial-guide",
             "docs/knowledge-base/getting-started/pricing-structure",
-            "docs/knowledge-base/getting-started/key-differentiators"
+            "docs/knowledge-base/getting-started/key-differentiators",
+            "docs/knowledge-base/getting-started/charlie-ai"
           ]
         },
         {
@@ -249,7 +250,8 @@
             "docs/knowledge-base/shovels-online/search-functionality",
             "docs/knowledge-base/shovels-online/filters-and-sorting",
             "docs/knowledge-base/shovels-online/permit-downloads",
-            "docs/knowledge-base/shovels-online/contractor-downloads"
+            "docs/knowledge-base/shovels-online/contractor-downloads",
+            "docs/knowledge-base/shovels-online/cancel-subscription"
           ]
         },
         {
@@ -309,7 +311,8 @@
                 "docs/knowledge-base/data/quality/verification-methods",
                 "docs/knowledge-base/data/quality/refresh-frequency",
                 "docs/knowledge-base/data/quality/labeling-process",
-                "docs/knowledge-base/data/quality/historical-data"
+                "docs/knowledge-base/data/quality/historical-data",
+                "docs/knowledge-base/data/quality/few-results"
               ]
             }
           ]
@@ -332,7 +335,9 @@
           "group": "Company",
           "pages": [
             "docs/knowledge-base/company/contact-information",
-            "docs/knowledge-base/company/property-types"
+            "docs/knowledge-base/company/property-types",
+            "docs/knowledge-base/company/refund-policy",
+            "docs/knowledge-base/company/data-usage-terms"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

Publishes the 5 Draft articles from the [Knowledge Base Updates](https://www.notion.so/shovels/Knowledge-Base-Updates-3595e14e735280b99540c5c09ea8708a) Notion tracker to the docs site, filed under the categories specified in the Notion `KB Category` column.

### New articles
- **Getting Started** — `docs/knowledge-base/getting-started/charlie-ai.mdx` (What is Charlie AI?)
- **Shovels Online** — `docs/knowledge-base/shovels-online/cancel-subscription.mdx` (How do I cancel my subscription?)
- **Company** — `docs/knowledge-base/company/refund-policy.mdx` (What is Shovels' refund policy?)
- **Company** — `docs/knowledge-base/company/data-usage-terms.mdx` (What can and can't I do with Shovels data?)
- **Data Quality** — `docs/knowledge-base/data/quality/few-results.mdx` (Why am I getting so few results?)

### Quick Answers / Glossary
- Quick Answers: added concise entries for all 5 articles in the existing Pricing & Plans / Data Coverage sections, plus a new **Charlie AI** section.
- Glossary: added **Charlie (Charlie AI)** under "C". The other articles are policy/how-to and don't introduce new vocabulary.

### Cross-links
Bidirectional links added between related articles:
- `free-trial-guide` ↔ `charlie-ai`
- `pricing-structure` ↔ `cancel-subscription`, `refund-policy`
- `cancel-subscription` ↔ `refund-policy`
- `coverage-areas`, `refresh-frequency`, `how-it-works` → `few-results`
- `contact-information` → `refund-policy`, `data-usage-terms`, `cancel-subscription`

### Navigation
- `mint.json` updated with all 5 new pages in their respective nav groups.
- `docs/knowledge-base/index.mdx` Popular Questions updated; new **Account & Billing** section added.

## Test plan

- [ ] `mintlify dev` renders all 5 new pages without errors
- [ ] Sidebar navigation shows the new pages in the correct groups
- [ ] Quick Answers and Glossary entries link to the new articles
- [ ] All cross-links resolve (no 404s)
- [ ] `mintlify broken-links` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)