### PR TITLE
Remove Parcels coming soon placeholder from EDL data dictionary

### DIFF
--- a/docs/data-dictionary-edl.mdx
+++ b/docs/data-dictionary-edl.mdx
@@ -217,8 +217,3 @@ mode: "wide"
     | company_naics | `string` | The North American Industry Classification System (NAICS) code of the company. | "123456" | Shovels |
     | address_id | `string` | The Shovels ID for the address of the resident. | "we8lsd25l08" | Shovels |
 </Accordion>
-<Accordion title="Parcels (coming soon)">
-    | Field Name | Data Type | Description | Example | Source |
-    |:-----------|:----------|:------------|:---------|:--------|
-    | Stay | Tuned | And | Check | Soon! |
-</Accordion>


### PR DESCRIPTION
## Summary

- Removes the "Parcels (coming soon)" accordion from the EDL Data Dictionary page
- The section contained only a placeholder row with no real data

## Test plan

- [ ] Navigate to the EDL Data Dictionary page and confirm the Parcels accordion no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)