### PR TITLE
Add June 2026 release notes (V2.1.9)

### DIFF
--- a/release-notes/release-notes.mdx
+++ b/release-notes/release-notes.mdx
@@ -4,6 +4,249 @@ icon: "code-merge"
 description: "Find out what the Engineering team has been up to across our entire platform, including general announcements, updates, and bugfixes."
 ---
 
+<Update label="V2.1.9" description="2026-06-01">
+  <Tabs>
+    <Tab title="Online">
+      ### Introduction
+
+      Our biggest data product launch since ReZone joins the platform: **Decisions** — the rezonings, variances, and planning votes that set a project in motion long before a permit is filed — is now available in beta. This release also adds **3.5M** new permits, **259** newly covered jurisdictions, and a new `window_door` project tag backfilled across history.
+
+      ### ✨ New
+
+      **Decisions (Beta)**
+
+      Zoning and land-use decisions — approvals, rezonings, and variances from city council and planning meetings — are now available in beta across **600+** cities and roughly **200K** records, about half the jurisdictions where we already track permits and growing weekly. Each decision is tied to its property and the people on it, and threads through to permits and jurisdictions. Available on every plan, including the free trial, and via Enterprise Data License.
+
+      **New `window_door` Project Tag**
+
+      A `window_door` tag was backfilled across the full permit history — **3,494,250** permits now carry it. It sits alongside the tags you already use (electrical, solar, HVAC, roofing…) and changes nothing else.
+
+      ### 🏗️ Permits Dataset
+
+      **New Permits Added**
+      - **+3,540,129** new permits added this release
+      - Net permits: **+3,386,216** (+2.3%)
+      - Total permits: **144,418,410**
+      - Permits newly linked to an address: **+2,456,748** (~74.6% coverage)
+
+      **New Permits by Type**
+      - Electrical: **+626,854** (+2.1%)
+      - Remodel: **+374,906** (+2.4%)
+      - Plumbing: **+371,673** (+2.1%)
+      - HVAC: **+354,223** (+2.2%)
+      - New construction: **+333,810** (+2.3%)
+      - Roofing: **+299,450** (+3.3%)
+      - Addition: **+140,302** (+2.3%)
+      - Gas: **+133,410** (+2.7%)
+      - Grading: **+104,828** (+1.8%)
+      - Water heater: **+97,222** (+2.7%)
+      - Pool & hot tub: **+72,289** (+2.9%)
+      - Solar: **+67,596** (+1.9%)
+      - ADU: **+52,943** (+2.3%)
+      - Demolition: **+49,633** (+2.1%)
+
+      **🗺️ Newly Covered Jurisdictions**
+
+      **259** new jurisdictions added this release (20+ permits each), **7** of them over 10,000 records. Highlights:
+      - CT / West Hartford: **59,265**
+      - FL / Holmes Beach: **38,531**
+      - PA / Wilkes-Barre: **36,494**
+      - FL / Haines City: **22,395**
+      - NC / Morganton: **16,894**
+      - NC / Hoke County: **16,671**
+      - CA / St. Helena: **16,489**
+      - OH / Fairborn: **9,499**
+      - WI / Greendale: **9,351**
+      - GA / Greene County: **8,365**
+      - Plus 249 more
+
+      ### 👷 Contractors
+
+      - Newly added: **+112,915**
+      - Net contractors: **+74,150** (+2.6%)
+      - Total contractors: **2,712,522**
+      - New contractor-license boards in AL, WI, KY, ME, and NC (plumbing & electrical)
+    </Tab>
+    <Tab title="API">
+      ### Introduction
+
+      **Decisions** is now in the API in beta — a new zoning and land-use data product — alongside a new `GET /v2/meta/coverage` endpoint, the additive `window_door` tag, and a faster, more resilient API. Several behavior and data changes need a look before they trip up your integration; review the Action Required sections first.
+
+      <Warning>
+        This release includes breaking changes to auth status codes, rate limiting, input validation, a permit status reclassification, and ~141K re-keyed permit IDs. Review the **Action Required** sections below.
+      </Warning>
+
+      ### ⚠️ Action Required: API Behavior Changes
+
+      **Auth errors now return `401` (was `403`)**
+
+      A missing or invalid `X-API-Key` now returns `401`. We've kept `403` for a valid key that lacks admin access. If your client branches on status codes, point the auth case at `401`.
+
+      **Rate limiting is live — `429`**
+
+      Per-key rate limiting starts at **120** requests per **60** seconds, per key — well above normal use. Exceed it and you'll get a `429` with a `Retry-After` header indicating how many seconds to wait. Make sure your client honors it and backs off. If that limit is too tight for your use case, contact support.
+
+      **`contractor_name` now requires at least 3 characters**
+
+      On `GET /v2/contractors/search`, a name under 3 characters now returns `422` instead of running a slow scan. Those names are still reachable by `id`, license, or geo.
+
+      ### ⚠️ Action Required: Data Changes
+
+      **141,793 permit IDs changed (~0.1%)**
+
+      These are the same permits — same jurisdiction, state, and `permit_number` — but their `file_date` shifted upstream, which moves the `id`. An `old_id → new_id` changelog is available; contact support to receive it. Most affected jurisdictions:
+      - TX / Temple: **48,203**
+      - FL / Seminole County: **41,899**
+      - FL / Escambia County: **16,539**
+      - CA / Bakersfield: **10,838**
+
+      **Some `address_id` links moved**
+      - Newly linked to an address: **165,427** (0.11%)
+      - Address link removed: **241,031** (0.17%)
+      - Re-matched to a different address: **119,534** (0.08%)
+
+      When a re-scraped permit no longer carries a published address, we drop the link; our matching also tightened. If you cache `address_id` joins, re-sync the affected permits.
+
+      **"Approved" permits now map to `IN_REVIEW`**
+
+      A bare "Approved" means plans cleared review but fees aren't paid yet — that's pre-issuance, so it now maps to `IN_REVIEW` rather than `ACTIVE`. Only `APPROVED FOR CONSTRUCTION` stays `ACTIVE`. Adjust any status-based filtering to match.
+
+      ### 🆕 Decisions API (Beta)
+
+      `GET /v2/decisions/search` · `GET /v2/decisions`
+
+      The approvals, rezonings, and variances that come out of city council and planning meetings — the decisions that set a project in motion long before a permit exists.
+      - **Coverage:** **600+** cities and roughly **200K** decision records today — about half the jurisdictions where we already have permits, and growing weekly.
+      - **Record shape:** each decision is tied to its property (address, coordinates, geo IDs) and to the people on it — applicants, owners, developers, architects, engineers — and threads through to permits and jurisdictions.
+      - **Access & price:** on every plan, including the free trial, and via Enterprise Data License. During beta it's **1** credit per decision; we'll notify you before that changes.
+      - **Usage:** works like `/v2/permits/search` — date range + `geo_id` required, cursor pagination, filters (asset class / category / subcategory / property type / project value / full-text), CSV export (≤1,000 rows), and batch-by-id at `/v2/decisions`.
+      - **Note:** the source has no ZIP, so ZIP-level `geo_id` filters return `422`.
+
+      ### 🆕 Data Coverage Endpoint
+
+      `GET /v2/meta/coverage`
+
+      Per-field fill rates for any state, county, city, ZIP, or jurisdiction, bucketed into tiers (under 10%, partial, over 80%). It saves you from filtering on a field in a place where we don't ingest it and wondering why results look thin.
+
+      ### 🆕 New Project Tag: `window_door`
+
+      A `window_door` tag was backfilled across the full permit history — **3,494,250** permits now carry it. It works in `permit_tags` right away and changes nothing else.
+
+      ### ⚡ API Enhancements
+      - **Billing:** hitting a credit or trial limit now returns a `402` with a Stripe `upgrade_url` so you can self-serve. Additive — nothing breaks.
+      - **Contractor search** now matches on business name, not just the contact name.
+      - **Address search** handles a ZIP inside the query and multi-word cities correctly, and resolves typos faster.
+      - **Geo search** no longer 500s on odd input — malformed geo IDs return a clean `422`.
+      - **Speed:** contractor-name filtering is quicker and database pressure under load is reduced.
+
+      ### 🧰 Shovels CLI
+      - New `coverage` command (under `cities`, `counties`, `jurisdictions`, `states`, `zipcodes`) wraps the new coverage endpoint, with date-window flags. It's credit-exempt.
+      - A `decisions` command is coming right behind this release.
+
+      ### 🏗️ Permits Dataset
+
+      **New Permits Added**
+      - **+3,540,129** new permits added this release
+      - Net permits: **+3,386,216** (+2.3%)
+      - Total permits: **144,418,410**
+      - Permits newly linked to an address: **+2,456,748** (~74.6% coverage)
+
+      **New Permits by Type**
+      - Electrical: **+626,854** (+2.1%)
+      - Remodel: **+374,906** (+2.4%)
+      - Plumbing: **+371,673** (+2.1%)
+      - HVAC: **+354,223** (+2.2%)
+      - New construction: **+333,810** (+2.3%)
+      - Roofing: **+299,450** (+3.3%)
+      - Addition: **+140,302** (+2.3%)
+      - Gas: **+133,410** (+2.7%)
+      - Grading: **+104,828** (+1.8%)
+      - Water heater: **+97,222** (+2.7%)
+      - Pool & hot tub: **+72,289** (+2.9%)
+      - Solar: **+67,596** (+1.9%)
+      - ADU: **+52,943** (+2.3%)
+      - Demolition: **+49,633** (+2.1%)
+
+      **🗺️ Newly Covered Jurisdictions**
+
+      **259** new jurisdictions added this release (20+ permits each), **7** of them over 10,000 records. Highlights:
+      - CT / West Hartford: **59,265**
+      - FL / Holmes Beach: **38,531**
+      - PA / Wilkes-Barre: **36,494**
+      - FL / Haines City: **22,395**
+      - NC / Morganton: **16,894**
+      - NC / Hoke County: **16,671**
+      - CA / St. Helena: **16,489**
+      - OH / Fairborn: **9,499**
+      - WI / Greendale: **9,351**
+      - GA / Greene County: **8,365**
+      - Plus 249 more
+
+      ### 👷 Contractors
+
+      - Newly added: **+112,915**
+      - Net contractors: **+74,150** (+2.6%)
+      - Total contractors: **2,712,522**
+      - New contractor-license boards in AL, WI, KY, ME, and NC (plumbing & electrical)
+    </Tab>
+    <Tab title="EDL (Enterprise Data License)">
+      ### 🆕 Decisions (Beta)
+
+      The new Decisions dataset — zoning and land-use approvals, rezonings, and variances across **600+** cities and roughly **200K** records — is available via Enterprise Data License, tied through to properties, people, permits, and jurisdictions.
+
+      ### 🏗️ Permits Dataset
+
+      **New Permits Added**
+      - **+3,540,129** new permits added this release
+      - Net permits: **+3,386,216** (+2.3%)
+      - Total permits: **144,418,410**
+      - Permits newly linked to an address: **+2,456,748** (~74.6% coverage)
+
+      **New Permits by Type**
+      - Electrical: **+626,854** (+2.1%)
+      - Remodel: **+374,906** (+2.4%)
+      - Plumbing: **+371,673** (+2.1%)
+      - HVAC: **+354,223** (+2.2%)
+      - New construction: **+333,810** (+2.3%)
+      - Roofing: **+299,450** (+3.3%)
+      - Addition: **+140,302** (+2.3%)
+      - Gas: **+133,410** (+2.7%)
+      - Grading: **+104,828** (+1.8%)
+      - Water heater: **+97,222** (+2.7%)
+      - Pool & hot tub: **+72,289** (+2.9%)
+      - Solar: **+67,596** (+1.9%)
+      - ADU: **+52,943** (+2.3%)
+      - Demolition: **+49,633** (+2.1%)
+
+      **🗺️ Newly Covered Jurisdictions**
+
+      **259** new jurisdictions added this release (20+ permits each), **7** of them over 10,000 records. Highlights:
+      - CT / West Hartford: **59,265**
+      - FL / Holmes Beach: **38,531**
+      - PA / Wilkes-Barre: **36,494**
+      - FL / Haines City: **22,395**
+      - NC / Morganton: **16,894**
+      - NC / Hoke County: **16,671**
+      - CA / St. Helena: **16,489**
+      - OH / Fairborn: **9,499**
+      - WI / Greendale: **9,351**
+      - GA / Greene County: **8,365**
+      - Plus 249 more
+
+      ### 👷 Contractors
+
+      - Newly added: **+112,915**
+      - Net contractors: **+74,150** (+2.6%)
+      - Total contractors: **2,712,522**
+      - New contractor-license boards in AL, WI, KY, ME, and NC (plumbing & electrical)
+
+      ### 🪟 Data Quality
+
+      A `window_door` project tag was backfilled across the full permit history — **3,494,250** permits now carry it.
+    </Tab>
+  </Tabs>
+</Update>
+
 <Update label="V2.1.8" description="2026-05-02">
   <Tabs>
     <Tab title="Online">


### PR DESCRIPTION
## What

Adds the **V2.1.9** (2026-06-01) entry to `release-notes/release-notes.mdx` — the June release notes Morgan was blocked from publishing.

Content is adapted from Luka's June 1 technical release-notes draft into the docs format per `CLAUDE.md`: three tabs (Online / API / EDL), monthly patch version bump (V2.1.8 → V2.1.9), bold-numbers-only formatting, and the API tab reflects the breaking changes rather than the "no breaking changes" box.

## Highlights

- **Decisions API (beta)** — new zoning/land-use data product, `/v2/decisions`
- **Coverage endpoint** — `GET /v2/meta/coverage`
- **`window_door` tag** backfilled across history (3,494,250 permits)
- **Action Required:** `401` auth codes, `429` rate limiting, `contractor_name` 3-char min, ~141K re-keyed permit IDs, address-link shifts, and "Approved" → `IN_REVIEW`
- Monthly dataset growth (+3.5M permits, 259 jurisdictions, +112K contractors)

## Validation

- `mintlify broken-links`: release-notes.mdx clean (no new broken links)
- Tag structure balanced (Update/Tabs/Tab/Warning)

## Please double-check before merge

- **Version label V2.1.9** — followed the monthly-patch convention in CLAUDE.md; confirm a flagship launch like Decisions shouldn't instead bump the minor (V2.2.0).
- **Numbers** are from the June 1 draft; totals (permits 144,418,410 / contractors 2,712,522) are computed from the May baseline + June deltas — sanity-check against final pipeline figures.