### PR TITLE
Fix /addresses/search examples to use q param

### DIFF
--- a/docs/knowledge-base/api/address-resolution/geo-id-lookup.mdx
+++ b/docs/knowledge-base/api/address-resolution/geo-id-lookup.mdx
@@ -11,7 +11,7 @@ The address search endpoint returns the `geo_id` associated with an address:
 
 ```bash
 curl -X GET \
-  "https://api.shovels.ai/v2/addresses/search?street=123+Main+St&city=San+Francisco&state=CA&zip=94102" \
+  "https://api.shovels.ai/v2/addresses/search?q=123+Main+St,+San+Francisco,+CA" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 

--- a/docs/knowledge-base/api/address-resolution/resolving-addresses.mdx
+++ b/docs/knowledge-base/api/address-resolution/resolving-addresses.mdx
@@ -16,7 +16,7 @@ Use the Address Search API endpoint to find addresses with permits in our system
 
 ```bash
 curl -X GET \
-  "https://api.shovels.ai/v2/addresses/search?street=123+Main+St&city=San+Francisco&state=CA" \
+  "https://api.shovels.ai/v2/addresses/search?q=123+Main+St,+San+Francisco,+CA" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 

--- a/docs/knowledge-base/api/errors/422-error.mdx
+++ b/docs/knowledge-base/api/errors/422-error.mdx
@@ -34,7 +34,7 @@ If the geo_id format is incorrect or wasn't obtained through address resolution.
 GET /v2/permits/search?street=123+Main+St  # Will return 422
 
 # RIGHT: Resolve address, then query permits
-GET /v2/addresses/search?street=123+Main+St&city=San+Francisco&state=CA
+GET /v2/addresses/search?q=123+Main+St,+San+Francisco,+CA
 # Get geo_id from response, then:
 GET /v2/permits/search?geo_id=RESOLVED_GEO_ID
 ```

--- a/docs/knowledge-base/api/permits/permit-search.mdx
+++ b/docs/knowledge-base/api/permits/permit-search.mdx
@@ -13,7 +13,7 @@ Use the [Search Addresses](/api-reference/addresses/search-addresses) endpoint w
 
 ```bash
 curl -X GET \
-  "https://api.shovels.ai/v2/addresses/search?street=123+Main+St&city=San+Francisco&state=CA" \
+  "https://api.shovels.ai/v2/addresses/search?q=123+Main+St,+San+Francisco,+CA" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 

--- a/docs/tutorial-api-address-permit-history.mdx
+++ b/docs/tutorial-api-address-permit-history.mdx
@@ -22,7 +22,7 @@ Let's get into it.
         In this example, we'll use cURL to make the request, and look for the address "123 Main St".
 
         ```bash
-        curl -X GET "https://api.shovels.ai/v2/addresses/search?address=123%20Main%20St" \
+        curl -X GET "https://api.shovels.ai/v2/addresses/search?q=123%20Main%20St" \
             -H "X-API-Key: YOUR_API_KEY_HERE"
         ```
 


### PR DESCRIPTION
## Summary

`GET /v2/addresses/search` accepts a single query parameter, `q` (required, string). Five docs examples passed non-existent params (`street`, `city`, `state`, `zip`, `address`) and omitted `q`, so each documented call returned **422**. Address resolution is the entry point to most API workflows (address → `geo_id` → permits), so these broken examples blocked users at the first step.

## Changes

Replaced the bad query params with `q` in:
- `docs/knowledge-base/api/errors/422-error.mdx`
- `docs/knowledge-base/api/address-resolution/resolving-addresses.mdx`
- `docs/knowledge-base/api/address-resolution/geo-id-lookup.mdx`
- `docs/knowledge-base/api/permits/permit-search.mdx`
- `docs/tutorial-api-address-permit-history.mdx`

The intentionally-wrong `permits/search?street=…` example in `422-error.mdx` (demonstrating a 422) was left as-is.

Fixes MAR-119

🤖 Generated with [Claude Code](https://claude.com/claude-code)