### PR TITLE
Remove fabricated offset/page pagination from API docs

### DIFF
--- a/docs/knowledge-base/api/basics/query-parameters.mdx
+++ b/docs/knowledge-base/api/basics/query-parameters.mdx
@@ -25,8 +25,7 @@ Filter permits by date ranges:
 
 Control result sets:
 - `size` - Number of records per page (default: 50, max: 100)
-- `cursor` - For cursor-based pagination (recommended)
-- `page` - Page number for offset-based pagination (deprecated)
+- `cursor` - For cursor-based pagination
 
 ## Example Requests
 

--- a/docs/knowledge-base/api/contractors/employee-data.mdx
+++ b/docs/knowledge-base/api/contractors/employee-data.mdx
@@ -16,7 +16,6 @@ The Shovels API provides a dedicated endpoint to retrieve employee information f
 ### Optional Parameters
 
 - `cursor` - For pagination through large result sets
-- `page` - Page number for offset-based pagination
 - `size` - Number of items per page (1-100)
 
 ## Sample Request

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -138,18 +138,17 @@ Where objects are returned as an array in the `items` field. When `next_cursor` 
 
 ### Pagination
 
-The API supports two types of pagination:
+The API uses cursor-based pagination:
 
-#### 1. Cursor-Based Pagination (Recommended)
+#### Cursor-Based Pagination
 
-Cursor-based pagination is the default and recommended method for paginating through results. It uses an opaque cursor token to maintain your position in the result set, offering better performance, consistency, and stability, especially for large datasets.
+Cursor-based pagination uses an opaque cursor token to maintain your position in the result set, offering better performance, consistency, and stability, especially for large datasets.
 
 ```json
 {
  "items": [...],
  "size": 50,
- "next_cursor": "eyJkYXR.lIjoiMjA.yMy0",
- "pagination_type": "cursor"
+ "next_cursor": "eyJkYXR.lIjoiMjA.yMy0"
 }
 ```
 
@@ -165,32 +164,6 @@ GET /v2/permits/search?size=10&cursor=eyJkYXR.lIjoiMjA.yMy0
 ```
 
 When there are no more results, the `next_cursor` value will be `null`.
-
-#### 2. Offset-Based Pagination (Deprecated)
-
-⚠️ **IMPORTANT**: Offset-based pagination is deprecated and will be removed in a future release. We recommend migrating to cursor-based pagination for better performance and reliability.
-
-This traditional pagination method uses page numbers and is less efficient:
-
-```json
-{
- "items": [...],
- "page": 1,
- "size": 50,
- "next_page": 2,
- "pagination_type": "offset"
-}
-```
-
-To use offset-based pagination, explicitly provide a `page` parameter in your request:
-
-```
-GET /v2/permits/search?page=1&size=50
-```
-
-#### Pagination Priority
-
-If both `cursor` and `page` parameters are provided in the same request, cursor-based pagination takes precedence.
 
 ### Versioning
 
@@ -295,9 +268,9 @@ Here are some examples:
 
 ```json Query Parameter Error
 {
-    "loc": ["query", "page"],
-    "msg": "Page must be a positive integer",
-    "type": "type_error.integer"
+    "loc": ["query", "size"],
+    "msg": "Input should be a valid integer",
+    "type": "int_parsing"
 }
 ```
 


### PR DESCRIPTION
## Summary

The API is cursor-only — there is no `page` parameter and no offset pagination. The docs invented an "Offset-Based Pagination (Deprecated)" section, a `pagination_type` response field, and `page` params that the API rejects. This brings the pagination contract in line with the real response envelope: `{ items, size, next_cursor, total_count }`.

## Changes (shovels-docs)

- `docs/shovels-api-introduction.mdx`: deleted the offset-pagination section and "Pagination Priority", removed `pagination_type` from JSON examples, reworded the intro/heading to cursor-only, and rekeyed the `page`-based 422 example to `size`.
- `docs/knowledge-base/api/contractors/employee-data.mdx`: removed the `page` param (endpoint accepts only `cursor` + `size`).
- `docs/knowledge-base/api/basics/query-parameters.mdx`: removed the fabricated `page` (offset, deprecated) param line.

The marketing-repo portion of this ticket (`content/posts/api-guide-2.md`) is handled in a separate PR in shovels-marketing.

Fixes MAR-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)