### PR TITLE
Fix contractor search params and service-area recipe

### DIFF
--- a/docs/knowledge-base/api/contractors/contractor-search.mdx
+++ b/docs/knowledge-base/api/contractors/contractor-search.mdx
@@ -18,19 +18,23 @@ Not every permit has an associated contractor. This depends on whether the juris
 
 ## Searching for Contractors
 
+<Info>
+`/contractors/search` requires `geo_id`, `permit_from`, and `permit_to` on every request. The date range filters to contractors who pulled permits within that window.
+</Info>
+
 ### By Name
 
-You can search by contractor name—either the full name or partial:
+Add the `contractor_name` filter (minimum 3 characters) to search by full or partial name:
 
 ```bash
 # Full name search
 curl -X GET \
-  "https://api.shovels.ai/v2/contractors/search?name=John+Smith+Panels" \
+  "https://api.shovels.ai/v2/contractors/search?geo_id=CA&permit_from=2024-01-01&permit_to=2024-12-31&contractor_name=John+Smith+Panels" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 
 # Partial name search
 curl -X GET \
-  "https://api.shovels.ai/v2/contractors/search?name=Smith" \
+  "https://api.shovels.ai/v2/contractors/search?geo_id=CA&permit_from=2024-01-01&permit_to=2024-12-31&contractor_name=Smith" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
@@ -40,7 +44,7 @@ Search for contractors in a specific area:
 
 ```bash
 curl -X GET \
-  "https://api.shovels.ai/v2/contractors/search?geo_id=94103" \
+  "https://api.shovels.ai/v2/contractors/search?geo_id=94103&permit_from=2024-01-01&permit_to=2024-12-31" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
@@ -49,10 +53,9 @@ curl -X GET \
 - **Address lookup** is fuzzy
 - **Contractor lookup** is exact, or you can search by part of the name
 
-For example, searching for "John Smith Panels" you can search by:
+For example, searching for "John Smith Panels" you can search by (minimum 3 characters):
 - "John"
 - "Joh"
-- "Sm"
 - "Panels"
 
 ## Contractor Information Available

--- a/docs/knowledge-base/api/contractors/service-area-lookup.mdx
+++ b/docs/knowledge-base/api/contractors/service-area-lookup.mdx
@@ -16,16 +16,16 @@ By analyzing permit data, you can determine:
 
 ### Step 1: Get Permits for a Contractor
 
-Use the `/v2/permits/search` endpoint to retrieve permits for a specific contractor:
+Use the `/v2/contractors/{id}/permits` endpoint to retrieve all permits associated with a specific contractor:
 
 ```bash
 curl -X GET \
-  'https://api.shovels.ai/v2/permits/search?contractor_id=YOUR_CONTRACTOR_ID&permit_from=2022-01-01&permit_to=2024-12-31' \
+  'https://api.shovels.ai/v2/contractors/YOUR_CONTRACTOR_ID/permits' \
   -H 'X-API-Key: YOUR_API_KEY_HERE'
 ```
 
 <Info>
-You need the contractor_id first. Get it by searching for the contractor using the contractors search endpoint.
+You need the contractor's `id` first. Get it from the [contractor search](/docs/knowledge-base/api/contractors/contractor-search) endpoint. Note that `/permits/search` has no `contractor_id` filter—this dedicated endpoint is the way to pull a single contractor's permits.
 </Info>
 
 ### Step 2: Extract Geographic Data
@@ -44,9 +44,9 @@ Process the permit data to create deduplicated lists of:
 
 ## Best Practices
 
-1. **Use Date Ranges** - Query recent permit data (last 2-3 years) for active service areas
+1. **Filter by Recency** - The endpoint returns the contractor's full permit history; filter client-side on permit dates (e.g. last 2-3 years) for active service areas
 2. **Handle Pagination** - Make sure to handle paginated responses to get complete permit histories
-3. **Filter by Property Type** - Use `property_type` parameters to understand different service area patterns (residential vs commercial)
+3. **Filter by Property Type** - Use each permit's `property_type` field to understand different service area patterns (residential vs commercial)
 
 ## Geographic Filtering Capabilities
 


### PR DESCRIPTION
## Summary

Two contractor-API docs had examples that fail against the real API.

**`contractor-search.mdx`** — `/contractors/search` requires `geo_id`, `permit_from`, and `permit_to` on every request, and the name filter is `contractor_name` (minLength 3), not `name`. The examples passed `name` and omitted the required params (→ 422). Added the required params, switched to `contractor_name`, and removed the 2-char "Sm" fuzzy-match example (below the minimum).

**`service-area-lookup.mdx`** — the recipe queried `/permits/search?contractor_id=…`, but `/permits/search` has no `contractor_id` filter. Repointed it at the dedicated `GET /contractors/{id}/permits` endpoint.

## ⚠️ Note for reviewer

The ticket suggested `GET /contractors/{id}/permits?permit_from=…&permit_to=…`, but the production OpenAPI spec shows that endpoint accepts only `cursor`, `size`, and `include_count` — **no date params**. I built the recipe per the spec (no date filter) and moved date/property-type narrowing to client-side steps. Flagging in case the date params are expected to exist.

Fixes MAR-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)