### PR TITLE
Fix Lists base path to singular /v2/list

### DIFF
--- a/docs/knowledge-base/api/basics/api-endpoints.mdx
+++ b/docs/knowledge-base/api/basics/api-endpoints.mdx
@@ -13,7 +13,7 @@ description: "Quick overview of Shovels API endpoints. For complete details, see
 | **Decisions** | `/v2/decisions/*` | Zoning and land use decisions |
 | **Contractors** | `/v2/contractors/*` | Contractor information |
 | **Addresses** | `/v2/addresses/*` | Address resolution to geo_ids |
-| **Lists** | `/v2/lists/*` | Predefined values (tags, property types) |
+| **Lists** | `/v2/list/*` | Predefined values (tags, property types) |
 | **Meta** | `/v2/meta/*` | API metadata and release info |
 
 ## Search vs Detail Endpoints

--- a/docs/knowledge-base/api/basics/api-endpoints.mdx
+++ b/docs/knowledge-base/api/basics/api-endpoints.mdx
@@ -13,7 +13,7 @@ description: "Quick overview of Shovels API endpoints. For complete details, see
 | **Decisions** | `/v2/decisions/*` | Zoning and land use decisions |
 | **Contractors** | `/v2/contractors/*` | Contractor information |
 | **Addresses** | `/v2/addresses/*` | Address resolution to geo_ids |
-| **Lists** | `/v2/list/*` | Predefined values (tags, property types) |
+| **Lists** | `/v2/list/*` | Predefined values (tags, zip codes) |
 | **Meta** | `/v2/meta/*` | API metadata and release info |
 
 ## Search vs Detail Endpoints


### PR DESCRIPTION
## Summary

`docs/knowledge-base/api/basics/api-endpoints.mdx` listed the Lists base path as `/v2/lists/*`, but the endpoints are singular: `GET /list/tags` and `GET /list/zip` → `/v2/list/*`. Verified against the production OpenAPI spec. The glossary already used the correct singular path, so this was an isolated typo.

Fixes MAR-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)