### PR TITLE
Fix paginated envelope count field to total_count object

### DIFF
--- a/docs/knowledge-base/api/basics/successful-requests.mdx
+++ b/docs/knowledge-base/api/basics/successful-requests.mdx
@@ -14,10 +14,15 @@ When your request succeeds, you'll receive:
 ```json
 {
   "items": [...],
+  "size": 50,
   "next_cursor": "...",
-  "total": 150
+  "total_count": { "value": 150, "relation": "eq" }
 }
 ```
+
+<Info>
+`total_count` is returned only when you pass `include_count=true` on the first page (no cursor). `relation` is `eq` for an exact count, or `gte` when the true count exceeds the 10,000 cap.
+</Info>
 
 ## Error Responses
 

--- a/docs/knowledge-base/api/errors/error-handling.mdx
+++ b/docs/knowledge-base/api/errors/error-handling.mdx
@@ -18,7 +18,9 @@ An empty `items` array with a 200 response is **not an error**—it means your q
 ```json
 {
   "items": [],
-  "total": 0
+  "size": 50,
+  "next_cursor": null,
+  "total_count": { "value": 0, "relation": "eq" }
 }
 ```
 


### PR DESCRIPTION
## Summary

The paginated envelope's count field is `total_count`, an object `{ value, relation }` (`relation` ∈ `eq`/`gte`) returned **only when** `include_count=true` — not a bare `total` integer. Updated the two response examples to the real envelope and added a note on when `total_count` appears and what `relation` means.

## Changes (shovels-docs)

- `docs/knowledge-base/api/basics/successful-requests.mdx`: `"total": 150` → `"total_count": { "value": 150, "relation": "eq" }`, added `size`.
- `docs/knowledge-base/api/errors/error-handling.mdx`: `"total": 0` → `"total_count": { "value": 0, "relation": "eq" }`, added `size`/`next_cursor`.

Verified against the production OpenAPI spec (`TotalCount` schema).

Fixes MAR-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)