### PR TITLE
Fix param and field name typos across API docs

### DIFF
--- a/docs/knowledge-base/api/address-resolution/state-zip-validation.mdx
+++ b/docs/knowledge-base/api/address-resolution/state-zip-validation.mdx
@@ -11,7 +11,7 @@ When using Shovels' API for address searches, it's important to understand how s
 
 If you provide an incorrect state or zip code when searching for addresses:
 - You won't receive an explicit error message
-- The API returns a 200 OK response with an empty result set (`null` items)
+- The API returns a 200 OK response with an empty result set (`items: []`)
 
 ## Why This Happens
 

--- a/docs/knowledge-base/api/contractors/employee-data.mdx
+++ b/docs/knowledge-base/api/contractors/employee-data.mdx
@@ -30,7 +30,7 @@ curl --request GET \
 ## Response Data
 
 ### Contact Information
-- `email` - Personal email address
+- `email` - Email address
 - `business_email` - Business email address
 - `phone` - Phone number
 - `linkedin_url` - LinkedIn profile

--- a/docs/knowledge-base/api/contractors/independent-contractors.mdx
+++ b/docs/knowledge-base/api/contractors/independent-contractors.mdx
@@ -5,9 +5,9 @@ description: "Learn reliable methods to identify sole proprietors and individual
 
 Identifying independent contractors (ICs) in the Shovels API can be accomplished in several ways.
 
-## Primary Method: biz_type Field
+## Primary Method: business_type Field
 
-The most reliable method is through the `biz_type` field, though it has limited coverage across our dataset.
+The most reliable method is through the `business_type` field, though it has limited coverage across our dataset.
 
 ## Heuristic Indicators
 
@@ -35,7 +35,7 @@ Understanding which contractors are independent professionals versus larger comp
 - Better targeting for products or services
 
 <Info>
-The `biz_type` field provides the most accurate identification when available, but coverage varies across the dataset.
+The `business_type` field provides the most accurate identification when available, but coverage varies across the dataset.
 </Info>
 
 ## Related Articles

--- a/docs/knowledge-base/api/permits/permits-by-state.mdx
+++ b/docs/knowledge-base/api/permits/permits-by-state.mdx
@@ -30,7 +30,7 @@ State-level searches can return many results. Consider adding filters:
 ?geo_id=CA&property_type=residential
 
 # Add permit type filter
-?geo_id=CA&tags=solar
+?geo_id=CA&permit_tags=solar
 
 # Combine with date range
 ?geo_id=CA&permit_from=2024-01-01&permit_to=2024-03-31

--- a/docs/knowledge-base/data/permits/permit-lifecycle.mdx
+++ b/docs/knowledge-base/data/permits/permit-lifecycle.mdx
@@ -21,7 +21,7 @@ The permit lifecycle typically flows through several stages:
 | Stage | Status | Date Field |
 |-------|--------|------------|
 | Filing | `in_review` | `file_date` |
-| Approval | `active` | `issued_date` |
+| Approval | `active` | `issue_date` |
 | Completion | `final` | `final_date` |
 | Abandoned/Revoked | `inactive` | - |
 


### PR DESCRIPTION
## Summary

Grouped small factual fixes across the API knowledge base, each correcting a name that doesn't match the API:

- `permits-by-state.mdx` — permit tag filter is `permit_tags`, not `tags`.
- `independent-contractors.mdx` — the field is `business_type`, not `biz_type`.
- `employee-data.mdx` — the `Employees` schema has a plain `email` field; dropped the "Personal" qualifier (that concept belongs to residents' `personal_emails`).
- `permit-lifecycle.mdx` — the permit date field is `issue_date`, not `issued_date`.
- `state-zip-validation.mdx` — no-match responses return an empty `items: []` array, not `null` items.

## ⚠️ Note for reviewer

The ticket flagged that the intended independent-contractor signal may actually be `classification` / `classification_derived` rather than `business_type`. I applied the literal `biz_type` → `business_type` typo fix (a real field) but did not change the *method* — worth confirming with the data team whether the page should pivot to `classification_derived`.

Fixes MAR-125

🤖 Generated with [Claude Code](https://claude.com/claude-code)