### PR TITLE
Frame decisions data-fields page as dataset schema

### DIFF
--- a/docs/knowledge-base/data/decisions/data-fields.mdx
+++ b/docs/knowledge-base/data/decisions/data-fields.mdx
@@ -1,9 +1,13 @@
 ---
 title: "Decision Data Fields"
-description: "A complete reference of all data fields available in Shovels Decisions, including metadata, zoning details, property information, and involved parties."
+description: "A complete reference of the Shovels Decisions dataset schema, including metadata, zoning details, property information, and involved parties. This documents the full dataset; the API exposes a subset under different names."
 ---
 
-Each Shovels Decision record contains structured data extracted from city council and planning department meetings. This reference covers all available fields.
+Each Shovels Decision record contains structured data extracted from city council and planning department meetings. This reference covers the complete **Decisions dataset** schema.
+
+<Info>
+This page documents the full Decisions **dataset**, a superset of what the API returns. The API `DecisionsRead` response exposes a subset of these fields, some under different names — notably `when` → `decision_date`, `link` → `source_url`, `applicant` → `applicant_name`, `owner` → `owner_name`, `developer` → `developer_name`, `representative` → `representative_name`, `address_1`/`address_2`/`address_3` → `street` / `city` / `state`, and `size_ac`/`size_sf` → `lot_size` (the API also adds `project_value`). See the [API Reference](/api-reference) for the exact API schema.
+</Info>
 
 ## Core Metadata
 
@@ -26,10 +30,13 @@ Each Shovels Decision record contains structured data extracted from city counci
 | `address_3` | Additional address |
 | `latitude` | GPS latitude coordinate |
 | `longitude` | GPS longitude coordinate |
-| `geo_ids` | Object containing `address_id`, `city_id`, `county_id`, `jurisdiction_id` |
+| `address_id` | Shovels address identifier |
+| `city_id` | Shovels city identifier |
+| `county_id` | Shovels county identifier |
+| `jurisdiction_id` | Shovels jurisdiction identifier |
 
 <Info>
-Geographic coordinates enable mapping and spatial analysis. The `geo_ids` field allows you to join decision data with other Shovels datasets.
+Geographic coordinates enable mapping and spatial analysis. The geographic identifiers (`address_id`, `city_id`, `county_id`, `jurisdiction_id`) are flat fields you can use to join decision data with other Shovels datasets. Unlike permits, decisions do not nest these in a `geo_ids` object.
 </Info>
 
 ## Zoning Details


### PR DESCRIPTION
## Summary

`docs/knowledge-base/data/decisions/data-fields.mdx` is framed as "all data fields available in Shovels Decisions" but uses field names that don't match the API `DecisionsRead` schema. The page lives under `knowledge-base/data/` and most of its extra fields (zoning descriptions, regulatory parameters, involved-party contacts, summary, newsworthiness) are legitimate **dataset** fields, not fabrications.

## Approach

Chose **option (a)** from the ticket — relabel the page as the full Decisions dataset schema (a superset of the API, like `data-dictionary-edl.mdx`) rather than deleting the richer dataset fields. Added an `<Info>` note mapping the dataset field names to their API `DecisionsRead` equivalents (`when`→`decision_date`, `link`→`source_url`, `applicant`→`applicant_name`, `owner`→`owner_name`, `developer`→`developer_name`, `representative`→`representative_name`, `address_1/2/3`→`street`/`city`/`state`, `size_ac`/`size_sf`→`lot_size`, plus `project_value`).

Also corrected the one outright error regardless of framing: decisions expose **flat** `address_id`/`city_id`/`county_id`/`jurisdiction_id` fields, not a nested `geo_ids` object (that nesting exists only on `PermitsRead`).

## Note for reviewer

If this page is meant to document the **API** response specifically (not the dataset), it should instead be pared down to the `DecisionsRead` fields (option b). I went with (a) because of the `data/` placement and the EDL-style superset framing — easy to switch if you'd prefer (b).

Fixes MAR-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)