### PR TITLE
Fix mismatched quote in tutorial curl command

### DIFF
--- a/docs/tutorial-api-address-permit-history.mdx
+++ b/docs/tutorial-api-address-permit-history.mdx
@@ -45,7 +45,7 @@ Let's get into it.
         You will also need to specify the `permit_from` and `permit_to` strings, which are required fields. These represent the time bounds to search for permits for the given address. 
 
         ```bash
-        curl -X GET "https://api.shovels.ai/v2/permits/search?geo_id=$GEO_ID&permit_from=YYYY-MM-DD&permit_to=YYYY-MM-DD' \
+        curl -X GET "https://api.shovels.ai/v2/permits/search?geo_id=$GEO_ID&permit_from=YYYY-MM-DD&permit_to=YYYY-MM-DD" \
             -H "X-API-Key: YOUR_API_KEY_HERE"
         ```
 


### PR DESCRIPTION
## Summary

In `docs/tutorial-api-address-permit-history.mdx`, the Step 3 curl command opened the URL with a double quote but closed it with a single quote, so the command won't run. Closed it with a matching double quote. The `/permits/search` path and params were already correct.

Fixes MAR-129

🤖 Generated with [Claude Code](https://claude.com/claude-code)