### PR TITLE
Docs: permit sourcing is first-party (fix stale 'left scraping to incumbents')

### DIFF
--- a/docs/foundations-understanding-permits.mdx
+++ b/docs/foundations-understanding-permits.mdx
@@ -20,11 +20,11 @@ That is our north star, and we're driving towards it every day.
 
 ## Permit Availability
 
-Online permit data brokers either have to source the data themselves by building their own scraping and processing pipelines, or they need to pay for a third party data provider to do that work for them. 
+Online permit data brokers either source the data themselves by building their own scraping and processing pipelines, or they pay a third-party data provider to do that work for them. 
 
-At Shovels, we've been focused on the processing side of the question, and left the scraping to the incumbent data providers. But even still, there are over 20,000 permit jurisdictions in the US, and no one has them all. 
+At Shovels, we do it ourselves. As of 2026 we source permits first-party — our own scraping and collection pipeline run across the country — rather than licensing from third-party providers. Even so, there are over 20,000 permit jurisdictions in the US, and no one has them all. 
 
-So we do our best with what the market has for sale, and combine different sources to ensure we get as much coverage as possible. But at the core, permit availability is a scraping and automation problem, with linearly-scaling costs for maintenance. And we're getting as much as we can. 
+So we run the collection ourselves and combine every source we can reach — including jurisdictions that publish nothing online, which our team activates directly — to maximize coverage. At the core, permit availability is a scraping and automation problem with linearly-scaling maintenance costs, and we invest in it directly rather than buying a snapshot. 
 
 ### Digitization
 


### PR DESCRIPTION
The **Permit Availability** section of `foundations-understanding-permits.mdx` still described Shovels as leaving scraping to incumbent data providers and working with "what the market has for sale." That predates the **April 2026 first-party pivot** (permits + contractors now run on our own pipeline).

Rewrote the three stale lines to reflect first-party sourcing. Prompted by Series A diligence prep — the published docs currently contradict the deck's first-party moat claim, which a technical diligence reader would hit.

No other content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)