### PR TITLE
Document CLI v0.8.0 properties commands

### DIFF
--- a/docs/knowledge-base/api/properties/absence-queries.mdx
+++ b/docs/knowledge-base/api/properties/absence-queries.mdx
@@ -49,8 +49,10 @@ Each row in an absence result includes a `trust` object:
 | `unresolved_rate` | Share of that jurisdiction's permits of this type that never linked to an address (0–1) |
 | `data_horizon` | The most recent date past which "no permit since D" is under-observed for this row. If your `permit_from` is later than this date, the answer is a guess about data that hasn't arrived yet |
 | `horizon_basis` | How the horizon was estimated: `measured`, `pooled`, or `prior` |
+| `trust_jurisdiction_basis` | Whether the trust join used the row's own jurisdiction (`own`), its ZIP's dominant one (`dominant`), or none |
+| `trust_jurisdiction_error_bar` | Measured error rate of that join — `0` on an `own` basis, and the 6.13% ZIP-dominant estimate error on a `dominant` basis |
 | `footprint_basis` | Whether coverage suppression could resolve this row's geography: `matched` or `unknown` |
-| `flags` | Row-level caveats, e.g. `since_d_beyond_horizon` |
+| `flags` | Row-level caveats, e.g. `since_d_beyond_horizon`, `untagged_permits_present`, `trust_row_missing` |
 
 The page-level `trust_summary` aggregates across returned rows:
 
@@ -78,5 +80,6 @@ Shovels knows permits, not installations. "No solar permit on record" is not the
 
 - [How to search for properties](/docs/knowledge-base/api/properties/property-search)
 - [Properties vs Permits: which endpoint?](/docs/knowledge-base/api/properties/properties-vs-permits)
+- [Absence searches from the CLI](/docs/knowledge-base/cli/absence-and-trust) — Same surface, with per-page `trust_summaries`
 - [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)
 - [API Reference: Search Properties](/api-reference/properties/search-properties)

--- a/docs/knowledge-base/api/properties/properties-by-id.mdx
+++ b/docs/knowledge-base/api/properties/properties-by-id.mdx
@@ -19,8 +19,15 @@ curl -X GET \
 
 - A property's `id` is its **address geolocation ID**—the same `id` returned by [Search Properties](/api-reference/properties/search-properties) and [Search Addresses](/api-reference/addresses/search-addresses).
 - Results come back **in request order**.
-- Unknown IDs are simply omitted from the response—there is no per-ID 404. If you request 50 IDs and get 48 rows back, two IDs weren't found.
-- A non-address geolocation ID (city, county, or jurisdiction) is rejected with a [422 error](/docs/knowledge-base/api/errors/422-error).
+- A valid address ID with no property behind it is simply omitted from the response—there is no per-ID 404. If you request 50 IDs and get 48 rows back, two IDs weren't found.
+- A string that can't be **decoded** as an address ID is a different case: it fails the whole request with a [422 error](/docs/knowledge-base/api/errors/422-error), naming the offending value and its position.
+- A non-address geolocation ID (city, county, or jurisdiction) is likewise rejected with a [422 error](/docs/knowledge-base/api/errors/422-error).
+
+<Warning>
+Only *unknown* IDs degrade gracefully. A single malformed or non-address ID costs you the entire batch, so validate IDs before sending 50 of them.
+</Warning>
+
+Rows returned here carry **no** `trust` object—the absence-trust surface exists only on [Search Properties](/api-reference/properties/search-properties).
 
 <Tip>
 Looking up a property by its assessor parcel number (APN)? APN is returned on every record for mapping into your own systems, but it is not searchable—APNs are county-specific, millions of them collide across counties, and roughly 30% of properties have none. Resolve the address to a `geo_id` instead.

--- a/docs/knowledge-base/cli/absence-and-trust.mdx
+++ b/docs/knowledge-base/cli/absence-and-trust.mdx
@@ -1,0 +1,147 @@
+---
+title: "How Do I Run Absence Searches in the CLI?"
+description: "Find properties with no permit of a given type using the Shovels CLI, and read the per-row trust object and per-page meta.trust_summaries array that score every absence answer."
+sidebarTitle: "Absence & Trust"
+---
+
+**Prefix a permit tag with `-` to find properties that have no permit of that type on record.** Because a property can look permit-free due to data coverage rather than reality, every absence answer carries trust metadata scoring how far to believe it.
+
+```bash
+shovels properties search --geo-id 92024 --permit-tags "-solar" --limit 10
+```
+
+You can combine absence with presence — `--permit-tags "roofing,-solar"` finds properties with a roofing permit but no solar permit.
+
+<Info>
+Properties are in **beta**, and the absence-trust surface in particular may still change in response to how it's used in practice.
+</Info>
+
+## How --permit-from Changes the Meaning
+
+| Query | Meaning |
+|---|---|
+| `--permit-tags "-solar"` | Never had a solar permit |
+| `--permit-tags "-solar" --permit-from 2020-01-01` | No solar permit **since** that date |
+| `--permit-tags "roofing,-solar" --permit-from 2020-01-01` | Roofing since 2020, and **never** any solar |
+
+Once any positive filter is present, the exclusion reverts to "never" — a property record carries only one date per work type, so per-filter dates can't be composed.
+
+<Warning>
+There is no `--permit-to`. "No roofing between 2018 and 2021" and "no solar before 2020" are not expressible, because a permit inside a closed window is hidden by a later one. Only "ever" and "since date D" work. Use `shovels permits search` for windows.
+</Warning>
+
+## Reading the Per-Row trust Object
+
+Each absence row carries a `trust` object:
+
+```json
+{
+  "unresolved_rate": 0.0769,
+  "coverage_tier": "high",
+  "data_horizon": "2026-01-12",
+  "horizon_basis": "pooled",
+  "trust_jurisdiction_basis": "own",
+  "trust_jurisdiction_error_bar": 0.0,
+  "footprint_basis": "matched",
+  "flags": ["untagged_permits_present"]
+}
+```
+
+| Field | Description |
+|---|---|
+| `coverage_tier` | Permit coverage bucket for the row's jurisdiction: `high`, `medium`, or `low` |
+| `unresolved_rate` | Share of that jurisdiction's permits of this tag that never linked to an address (0-1) |
+| `data_horizon` | The most recent date past which "no permit since D" is under-observed. If your `--permit-from` is later than this, the answer is a guess about data that hasn't arrived yet |
+| `horizon_basis` | How the horizon was estimated: `measured`, `pooled`, or `prior` |
+| `trust_jurisdiction_basis` | Whether the trust join used the row's own jurisdiction (`own`), its ZIP's dominant one (`dominant`), or none |
+| `trust_jurisdiction_error_bar` | Measured error rate of that join — `0` on an `own` basis, and the 6.13% ZIP-dominant estimate error on a `dominant` basis |
+| `footprint_basis` | Whether coverage suppression could resolve the row's geography: `matched` or `unknown` |
+| `flags` | Row-level caveats, e.g. `since_d_beyond_horizon`, `untagged_permits_present`, `trust_row_missing` |
+
+<Tip>
+For lead generation, filter to rows with `coverage_tier == "high"`, an empty `flags` array, a `data_horizon` at or after your `--permit-from`, and `trust_jurisdiction_basis == "own"`:
+
+```bash
+shovels properties search --geo-id CA --permit-tags "-solar" --limit all \
+  | jq '.data[] | select(.trust.coverage_tier == "high"
+        and (.trust.flags | length) == 0
+        and .trust.trust_jurisdiction_basis == "own")'
+```
+</Tip>
+
+## meta.trust_summaries Is an Array, One Entry Per API Page
+
+This is the one place CLI output differs structurally from the REST API. The API returns a single `trust_summary` per page, scoped to that page's rows. The CLI's `--limit` merges pages — so it collects each page's summary into a **`meta.trust_summaries` array** rather than combining them:
+
+```bash
+shovels properties search --geo-id 92024 --permit-tags "-solar" --limit 205
+```
+
+```json
+{
+  "meta": {
+    "count": 205,
+    "has_more": true,
+    "credits_used": 205,
+    "trust_summaries": [
+      { "rows_flagged": 95,  "row_weighted_unresolved_rate": 0.0416, "expected_miss_rate": 0.0416, "suppressed_scopes": 0 },
+      { "rows_flagged": 100, "row_weighted_unresolved_rate": 0.0320, "expected_miss_rate": 0.0320, "suppressed_scopes": 0 },
+      { "rows_flagged": 5,   "row_weighted_unresolved_rate": 0.0320, "expected_miss_rate": 0.0320, "suppressed_scopes": 0 }
+    ]
+  }
+}
+```
+
+205 records came back as three API pages (100 + 100 + 5), so there are three summaries.
+
+<Warning>
+**The CLI does not aggregate these, and you shouldn't average them either.** Each rate is row-weighted over its own page, so a plain mean across pages of unequal size is wrong. The CLI has no basis on which to re-derive a correct merged figure, so it hands you the raw per-page values instead of inventing one.
+</Warning>
+
+| Field | Description |
+|---|---|
+| `expected_miss_rate` | The headline number: estimated probability that a returned "no permit" answer is wrong because the permit hasn't arrived yet |
+| `rows_flagged` | Rows on that page carrying a trust flag |
+| `row_weighted_unresolved_rate` | Row-weighted mean `unresolved_rate` across that page |
+| `suppressed_scopes` | Coverage scopes removed from the result by suppression |
+
+Read the worst page rather than the average when you need one number to act on:
+
+```bash
+shovels properties search --geo-id 92024 --permit-tags "-solar" --limit 205 \
+  | jq '[.meta.trust_summaries[].expected_miss_rate] | max'
+```
+
+An index in the array is **not** a page number: pages that carry no summary contribute no entry.
+
+## Presence-Only Searches Carry No Trust Surface
+
+Drop the `-` and both the row-level `trust` object and `meta.trust_summaries` disappear entirely:
+
+```bash
+$ shovels properties search --geo-id 92024 --permit-tags solar --limit 1
+{"data":[{"id":"...", "...": "..."}],"meta":{"count":1,"has_more":true,"credits_used":1}}
+```
+
+The key is omitted rather than returned empty, so in a script test for presence before reading it:
+
+```bash
+jq 'if .meta.trust_summaries then [.meta.trust_summaries[].expected_miss_rate] | max else null end'
+```
+
+## What Suppression Does to Your Result
+
+Where coverage for a work type in an area is too thin to answer honestly, those properties are **dropped from the result entirely** rather than returned as false negatives. `suppressed_scopes` reports how many scopes were removed.
+
+This means an absence search can legitimately return fewer rows — or zero rows — in a low-coverage area, while the same query returns plenty in a well-covered one. That's suppression working, not a bug.
+
+<Warning>
+Shovels knows permits, not installations. "No solar permit on record" is not the same claim as "no solar panels" — unpermitted work exists. Trust fields quantify data coverage, not construction reality.
+</Warning>
+
+## Related Articles
+
+- [Querying properties from the CLI](/docs/knowledge-base/cli/properties) — Full command and flag reference
+- [Finding properties with no permit on record](/docs/knowledge-base/api/properties/absence-queries) — The same surface via the REST API
+- [CLI output and pagination](/docs/knowledge-base/cli/output-and-pagination) — How `--limit` assembles pages
+- [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results) — Coverage and suppression

--- a/docs/knowledge-base/cli/commands-overview.mdx
+++ b/docs/knowledge-base/cli/commands-overview.mdx
@@ -4,7 +4,7 @@ description: "A complete overview of Shovels CLI commands for searching permits,
 sidebarTitle: "Commands Overview"
 ---
 
-**The CLI organizes commands into groups: permits, contractors, addresses, geographic lookups, tags, usage, and config.** Every command outputs JSON to stdout and supports `--help` for detailed usage.
+**The CLI organizes commands into groups: permits, properties, contractors, decisions, addresses, geographic lookups, tags, schema, usage, and config.** Every command outputs JSON to stdout and supports `--help` for detailed usage.
 
 ## Command Reference
 
@@ -28,6 +28,29 @@ shovels permits search \
   --property-type residential \
   --limit 50
 ```
+
+### properties
+
+Search properties with their permit history rolled up onto each record. Added in **v0.8.0**.
+
+| Subcommand | Description | Key Flags |
+|---|---|---|
+| `properties search` | Search properties by geographic scope and/or legal owner | `--geo-id` **or** `--legal-owner` (at least one) |
+| `properties get` | Retrieve 1-50 properties by address ID | Positional IDs |
+
+**Example: Properties with no solar permit**
+
+```bash
+shovels properties search \
+  --geo-id 92024 \
+  --permit-tags "-solar" \
+  --property-type residential \
+  --limit 10
+```
+
+<Info>
+Properties are in **beta**. Unlike `permits search`, there is no `--permit-to` flag and jurisdiction geo_ids are rejected. Tags are passed as one comma-separated value rather than a repeatable flag. See [Querying properties from the CLI](/docs/knowledge-base/cli/properties).
+</Info>
 
 ### contractors
 
@@ -56,17 +79,32 @@ shovels contractors search \
 Contractor search supports state, county, city, jurisdiction, and ZIP code geo_ids, but **not** address-level geo_ids. Use `permits search` for address-level queries.
 </Info>
 
+### decisions
+
+Search municipal zoning and land-use decisions. Added in **v0.7.0**.
+
+| Subcommand | Description | Key Flags |
+|---|---|---|
+| `decisions search` | Search decisions by location, date range, and category | `--decision-from`, `--decision-to` (both required) |
+| `decisions get` | Retrieve decisions by ID | Positional IDs |
+
+```bash
+shovels decisions search --geo-id CA \
+  --decision-from 2024-01-01 --decision-to 2024-12-31 \
+  --category Rezoning --asset-class Residential
+```
+
 ### addresses
 
-Search for addresses to resolve geo_ids.
+Search for addresses to resolve geo_ids, plus resident and metrics lookups.
 
 ```bash
 shovels addresses search -q "1600 Pennsylvania Ave"
 ```
 
-Returns matching addresses with their `geo_id`, formatted name, and coordinates.
+Returns matching addresses with their `geo_id`, formatted name, and coordinates. Also supports `addresses residents` and `addresses metrics current|monthly`.
 
-### cities, counties, jurisdictions
+### cities, counties, jurisdictions, states, zipcodes
 
 Resolve geographic names to geo_ids for use in search commands.
 
@@ -74,7 +112,35 @@ Resolve geographic names to geo_ids for use in search commands.
 shovels cities search -q "Miami Beach"
 shovels counties search -q "Los Angeles"
 shovels jurisdictions search -q "San Francisco"
+shovels states search -q "CA"
+shovels zipcodes search -q "941"
 ```
+
+<Info>
+`states search` matches on the 2-letter abbreviation (`CA`), not the full state name. `zipcodes search` matches on ZIP prefix and spans states, so filter the results if you need one state.
+</Info>
+
+Each group also exposes a `coverage` subcommand reporting which permit fields are reliably populated for that area. The geo_id is a **positional** argument here, and both dates are required. Cities, counties, and jurisdictions additionally support `metrics current` and `metrics monthly`.
+
+```bash
+shovels cities coverage Q2l0eXxGTHxNaWFtaSBCZWFjaA \
+  --coverage-from 2024-01-01 --coverage-to 2024-12-31
+```
+
+### schema
+
+Print the annotated JSON response schema for any data command — **offline, with no API call and no API key required**.
+
+```bash
+shovels schema                      # List all available command paths
+shovels schema properties search    # Full schema for one command
+```
+
+Each schema gives `response_fields` (type, description, unit, range, enum), `meta_fields` for commands whose meta carries more than the standard keys, a jq-ready `field_index`, and `filters` mapping each CLI flag to its type. Nested objects appear as dotted paths like `trust.coverage_tier`.
+
+<Tip>
+This is the cheapest way for an AI agent to learn a command's output shape before spending credits. Any data command also accepts `--schema` to print its own: `shovels properties search --schema`.
+</Tip>
 
 ### tags
 
@@ -113,7 +179,15 @@ shovels version
 
 ## Common Search Filters
 
-These flags are available on `permits search` and `contractors search`:
+These flags are available on `permits search` and `contractors search`. `properties search` uses a different flag shape — see [Querying properties from the CLI](/docs/knowledge-base/cli/properties):
+
+| Difference | `permits` / `contractors` | `properties` |
+|---|---|---|
+| Tag flag | `--tags`, repeatable or comma-separated | `--permit-tags`, one comma-separated value only — repeating it silently keeps just the last |
+| Date range | `--permit-from` **and** `--permit-to`, both required | `--permit-from` only; no upper bound exists |
+| Scope | `--geo-id` required | `--geo-id` **or** `--legal-owner` |
+| Attribute prefix | `--min-market-value` | `--property-min-market-value` |
+| Jurisdiction geo_ids | Accepted by `permits search` | Rejected |
 
 ### Tag Filters
 
@@ -171,6 +245,12 @@ These flags apply to all commands:
 | `--base-url` | Override API endpoint | Config or default |
 | `--no-retry` | Disable automatic retry on rate limits | `false` |
 | `--timeout` | Per-request timeout (Go duration format) | `30s` |
+| `--dry-run` | Print the resolved HTTP request as JSON without calling the API or spending credits | `false` |
+| `--schema` | Print this command's annotated response schema (offline, no auth) | `false` |
+
+<Tip>
+`--dry-run` and `--schema` both short-circuit before any network call, so they're free. Use `--dry-run` to confirm how your flags map to query parameters, and `--schema` to learn the response shape.
+</Tip>
 
 ## Getting Help
 
@@ -185,5 +265,7 @@ shovels permits search --help   # Detailed search flags and examples
 ## Related Articles
 
 - [CLI quickstart guide](/docs/shovels-cli-quickstart) — First query in under a minute
+- [Querying properties from the CLI](/docs/knowledge-base/cli/properties) — The `properties` command group
+- [CLI absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust) — Finding properties with no permit on record
 - [Output format and pagination](/docs/knowledge-base/cli/output-and-pagination) — Understanding JSON responses
 - [Scripting and AI agents](/docs/knowledge-base/cli/scripting-and-agents) — Composing CLI commands into workflows

--- a/docs/knowledge-base/cli/error-codes.mdx
+++ b/docs/knowledge-base/cli/error-codes.mdx
@@ -66,6 +66,38 @@ Fix: Add the required `--permit-from` and `--permit-to` flags.
 
 Fix: Ensure your `--permit-from` date is earlier than `--permit-to`. Use `YYYY-MM-DD` format.
 
+**Properties search validation:**
+
+`properties search` validates locally before making any API call, so these cost no credits:
+
+| Error | Cause |
+|---|---|
+| `at least one of --geo-id or --legal-owner required` | No scope given |
+| `--legal-owner values must not be empty` | An empty string was passed to `--legal-owner` |
+| `maximum 10 --legal-owner values per request, got 11` | More than 10 owners |
+| `invalid date format for --permit-from: "08-2026" (expected YYYY-MM-DD)` | Malformed date |
+| `--property-min-lot-size must not be negative, got -5` | Negative range bound |
+| `--property-min-year-built (2000) must not exceed --property-max-year-built (1990)` | Inverted range pair |
+| `unknown flag: --permit-to` | `properties search` has no upper date bound — use `permits search` |
+
+<Info>
+Auth is checked **before** local flag validation, so a missing API key surfaces as exit `2` even when your flags are also invalid. Fix the key first, then the flags.
+</Info>
+
+**Properties get ID errors:**
+
+An ID that is well-formed but has no property behind it is *not* an error — the row is omitted and the ID appears in `meta.missing` with exit `0`. Two cases do fail the whole request with exit `1`:
+
+```bash
+$ shovels properties get BJjCWAMtccQ NOT_A_REAL_ID
+{"error":"...Could not decode property id 'NOT_A_REAL_ID' at position 2. Each id must be an ADDRESS geolocation id...","code":1,"error_type":"validation_error"}
+
+$ shovels properties get RMjg6rIIh2k
+{"error":"...Property id 'RMjg6rIIh2k' at position 0 is a city, county, or jurisdiction id, not an ADDRESS id...","code":1,"error_type":"validation_error"}
+```
+
+Fix: pass only address IDs, from a `properties search` row's `id` or from `addresses search`. One bad ID takes down the entire batch, so validate before sending 50.
+
 ### Exit 2: Auth Error
 
 ```json
@@ -137,5 +169,6 @@ esac
 ## Related Articles
 
 - [CLI authentication](/docs/knowledge-base/cli/authentication) — Configure your API key
+- [Querying properties from the CLI](/docs/knowledge-base/cli/properties) — Properties flags and ID rules
 - [API error handling](/docs/knowledge-base/api/errors/error-handling) — REST API error codes
 - [API credit limits](/docs/knowledge-base/api/basics/credit-limits) — Understanding credit consumption

--- a/docs/knowledge-base/cli/installation.mdx
+++ b/docs/knowledge-base/cli/installation.mdx
@@ -14,13 +14,15 @@ The binary installs to `~/.shovels/bin` by default.
 
 ## Supported Platforms
 
-| OS | Architecture | Binary |
+| OS | Architecture | Release Asset |
 |---|---|---|
-| macOS | Apple Silicon (arm64) | `shovels-darwin-arm64` |
-| macOS | Intel (amd64) | `shovels-darwin-amd64` |
-| Linux | arm64 | `shovels-linux-arm64` |
-| Linux | amd64 | `shovels-linux-amd64` |
-| Windows | amd64 | `shovels-windows-amd64.exe` |
+| macOS | Apple Silicon (arm64) | `shovels_<version>_darwin_arm64.tar.gz` |
+| macOS | Intel (amd64) | `shovels_<version>_darwin_amd64.tar.gz` |
+| Linux | arm64 | `shovels_<version>_linux_arm64.tar.gz` |
+| Linux | amd64 | `shovels_<version>_linux_amd64.tar.gz` |
+| Windows | amd64 | `shovels_<version>_windows_amd64.zip` |
+
+Releases ship as compressed archives containing the `shovels` binary — for example `shovels_0.8.0_darwin_arm64.tar.gz`.
 
 ## Install Script Options
 
@@ -44,11 +46,12 @@ Download binaries directly from [GitHub Releases](https://github.com/ShovelsAI/s
 
 ```bash
 # Example: download and verify on macOS arm64
-curl -LO https://github.com/ShovelsAI/shovels-cli/releases/latest/download/shovels-darwin-arm64
-curl -LO https://github.com/ShovelsAI/shovels-cli/releases/latest/download/checksums.txt
+curl -LO https://github.com/ShovelsAI/shovels-cli/releases/download/v0.8.0/shovels_0.8.0_darwin_arm64.tar.gz
+curl -LO https://github.com/ShovelsAI/shovels-cli/releases/download/v0.8.0/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
-chmod +x shovels-darwin-arm64
-mv shovels-darwin-arm64 /usr/local/bin/shovels
+tar -xzf shovels_0.8.0_darwin_arm64.tar.gz
+chmod +x shovels
+mv shovels /usr/local/bin/shovels
 ```
 
 ## Add to PATH

--- a/docs/knowledge-base/cli/output-and-pagination.mdx
+++ b/docs/knowledge-base/cli/output-and-pagination.mdx
@@ -24,23 +24,7 @@ sidebarTitle: "Output & Pagination"
 }
 ```
 
-### Single Object Responses (get commands with one ID)
-
-```json
-{
-  "data": {
-    "id": "...",
-    "name": "...",
-    "permit_count": 42
-  },
-  "meta": {
-    "credits_used": 1,
-    "credits_remaining": 9999
-  }
-}
-```
-
-### Batch Responses (get commands with multiple IDs)
+### Batch Responses (get commands)
 
 ```json
 {
@@ -57,7 +41,19 @@ sidebarTitle: "Output & Pagination"
 }
 ```
 
-The `missing` array lists any IDs that weren't found.
+The `missing` array lists any IDs that weren't found, and is **omitted entirely** when every requested ID resolved.
+
+<Info>
+`data` is always an **array** on `get` commands, including when you request a single ID. Write `jq '.data[0]'` rather than `jq '.data'` so a one-ID lookup and a fifty-ID batch parse the same way.
+</Info>
+
+### Credit Fields
+
+`credits_remaining` appears only when your account has a credit limit. On uncapped plans the key is absent while `credits_used` is still reported, so test for it before reading it:
+
+```bash
+jq '.meta.credits_remaining // "uncapped"'
+```
 
 ## Pagination with --limit
 
@@ -121,9 +117,32 @@ shovels permits search --geo-id 92024 \
 Total counts are exact up to 10,000 (`"relation": "eq"`). Above 10,000, the count is approximate (`"relation": "gte"` means "at least this many").
 </Info>
 
+## Per-Page Metadata: meta.trust_summaries
+
+Most `meta` fields are aggregated across the pages `--limit` fetched. One is not.
+
+Absence searches on `properties search` return a trust summary **per API page**, scoped to that page's rows. Since no single summary is correct for a merged result, the CLI collects them into a `meta.trust_summaries` array instead of combining them:
+
+```json
+{
+  "meta": {
+    "count": 205,
+    "has_more": true,
+    "credits_used": 205,
+    "trust_summaries": [
+      { "rows_flagged": 95,  "expected_miss_rate": 0.0416, "suppressed_scopes": 0 },
+      { "rows_flagged": 100, "expected_miss_rate": 0.0320, "suppressed_scopes": 0 },
+      { "rows_flagged": 5,   "expected_miss_rate": 0.0320, "suppressed_scopes": 0 }
+    ]
+  }
+}
+```
+
+Three entries because 205 records arrived as three pages (100 + 100 + 5). The key is omitted entirely when a query has no absence filter. See [CLI absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust).
+
 ## Credit Tracking
 
-Every response includes `credits_used` and `credits_remaining` in the `meta` object. This lets you monitor usage without making a separate API call.
+Every response includes `credits_used` in the `meta` object, plus `credits_remaining` on plans with a credit limit. This lets you monitor usage without making a separate API call.
 
 To check your overall credit status:
 
@@ -139,11 +158,18 @@ shovels usage
 | Money amounts | Integer cents | `150000` = $1,500.00 |
 | Ratings | Float 0-5 | `4.2` |
 | Pass rates | Integer 0-100 | `85` (percentage) |
-| Coordinates | `[lat, lng]` float array | `[32.87, -117.25]` |
+| Coordinates (permits, addresses) | `address.latlng` as `[lat, lng]` float array | `[33.071202, -117.300993]` |
+| Coordinates (properties) | Separate `lat` and `long` floats | `33.066977`, `-117.247426` |
 | geo_ids | Base64-encoded string | `"Q2l0eXxGTHxNaWFtaQ"` |
+| Rate fields (trust) | Float 0-1 | `0.0769` = 7.69% |
+
+<Tip>
+Run `shovels schema <command>` to get every field's type and unit for a specific command, offline and without spending credits.
+</Tip>
 
 ## Related Articles
 
 - [CLI commands overview](/docs/knowledge-base/cli/commands-overview) — Full list of commands and flags
+- [CLI absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust) — Reading `meta.trust_summaries`
 - [CLI error codes](/docs/knowledge-base/cli/error-codes) — Understanding error responses
 - [Scripting and AI agents](/docs/knowledge-base/cli/scripting-and-agents) — Piping CLI output into workflows

--- a/docs/knowledge-base/cli/properties.mdx
+++ b/docs/knowledge-base/cli/properties.mdx
@@ -1,0 +1,275 @@
+---
+title: "How Do I Query Properties from the CLI?"
+description: "Use shovels properties search and shovels properties get to query US properties with their permit history rolled up onto each record, including owner, attribute, and absence filters."
+sidebarTitle: "Properties"
+---
+
+**The `properties` command group returns one row per property, with that property's permit history already rolled up onto the record.** A single row answers "what has happened at this address" — permit counts, work-type tags, latest activity dates, contractors, job values, and property attributes.
+
+Added in CLI **v0.8.0**. Run `shovels version` to check yours; upgrade with `curl -LsSf https://shovels.ai/install.sh | sh`.
+
+<Info>
+Properties are currently in **beta**. Query parameters, response fields, and the absence-trust surface may still change. Treat the response shape as unstable.
+</Info>
+
+## Subcommands
+
+| Subcommand | Description | Key Flags |
+|---|---|---|
+| `properties search` | Search properties by geographic scope and/or legal owner | `--geo-id` **or** `--legal-owner` (at least one) |
+| `properties get` | Retrieve 1-50 properties by address ID | Positional IDs |
+
+## Required Scope
+
+Every search needs a scope: `--geo-id`, `--legal-owner`, or both. Omitting both fails locally before any API call:
+
+```bash
+$ shovels properties search --permit-tags solar
+{"error":"at least one of --geo-id or --legal-owner required","code":1,"error_type":"validation_error"}
+```
+
+### --geo-id
+
+| Format | Example | Notes |
+|---|---|---|
+| ZIP code | `92024` | Use directly |
+| ZIP+4 | `92024-1234` | Use directly |
+| State | `CA` | 2-letter code |
+| City, county, or address | `RMjg6rIIh2k` | Resolve first with a search command |
+
+```bash
+shovels properties search \
+  --geo-id "$(shovels counties search -q 'San Diego' | jq -r '.data[0].geo_id')" \
+  --permit-tags solar --permit-status final --limit 10
+```
+
+<Warning>
+Jurisdiction geo_ids are **rejected** by this endpoint. Jurisdiction is recorded on only a minority of property records, so scoping to it would silently drop properties that were never permitted. Scope by city, county, state, or address instead.
+</Warning>
+
+### --legal-owner
+
+Repeat the flag for up to 10 owners. Values are **never split on commas**, so `"SMITH, JOHN"` is one owner, not two. Matching is on the owner's canonical form, so casing variants collapse together.
+
+```bash
+# Owner portfolio nationwide — no geographic scope needed
+shovels properties search --legal-owner "INVITATION HOMES" --include-count --limit 2
+```
+
+```json
+{
+  "data": [
+    {
+      "id": "DWe15mBxY8Y",
+      "city": "HOFFMAN ESTATES",
+      "state": "IL",
+      "legal_owner": "Invitation Homes",
+      "owner_type": "company_owned",
+      "permit_count": 3
+    }
+  ],
+  "meta": {
+    "count": 2,
+    "has_more": true,
+    "total_count": { "value": 151, "relation": "eq" },
+    "credits_used": 2
+  }
+}
+```
+
+`--legal-owner` is the one filter that works nationwide with no location at all.
+
+## Permit Filters
+
+| Flag | Description |
+|---|---|
+| `--permit-tags` | Canonical tags as **one comma-separated value** (e.g. `"solar,-roofing"`). A bare tag keeps properties that have it; a `-` prefix keeps properties **without** it |
+| `--permit-status` | One comma-separated value: `final`, `in_review`, `inactive`, `active` |
+| `--permit-from` | Binds the tag, status, and absence filters to this date (`YYYY-MM-DD`) |
+| `--permit-tags-unfinaled` | Keeps properties with an **unfinaled** permit of each named tag |
+
+<Warning>
+**There is no `--permit-to` flag.** A property record keeps only the latest permit date per work type, so a closed date window can't be answered correctly. Passing it fails as an unknown flag. Use `shovels permits search` for date windows and upper bounds.
+</Warning>
+
+Note the flag-shape difference from `permits search`: properties takes tags as a single comma-separated string, where `permits search` uses a repeatable `--tags`.
+
+<Warning>
+`--permit-tags` is a single value, so **repeating it silently keeps only the last one**. `--permit-tags solar --permit-tags roofing` searches for `roofing` alone, with no error. Write `--permit-tags "solar,roofing"` instead.
+
+`--property-type` is different — it accepts both repetition and a comma-separated value, and both forms keep every value.
+</Warning>
+
+Use `--dry-run` to confirm what your flags actually resolved to:
+
+```bash
+$ shovels properties search --geo-id 92024 --permit-tags solar --permit-tags roofing --dry-run
+{"method":"GET","url":"...","params":{"geo_id":"92024","permit_tags":["roofing"],"size":50}}
+```
+
+### Finding unfinaled work
+
+A permit that was pulled but never finaled often signals an unfinished job — for example an installer that went out of business mid-project.
+
+```bash
+shovels properties search --geo-id CA \
+  --permit-tags-unfinaled solar --permit-from 2024-01-01 --limit 2
+```
+
+Each row's `last_unfinaled_date_by_tag` shows when the unfinished work started:
+
+```json
+{
+  "id": "BApEVBRuBBM",
+  "city": "PISMO BEACH",
+  "last_unfinaled_date_by_tag": { "solar": "2026-08-16" }
+}
+```
+
+<Tip>
+"Unfinaled" is determined from permit **status**, not from a missing `final_date`. See [Finding unfinaled permits](/docs/knowledge-base/api/properties/unfinaled-permits) for why that distinction matters.
+</Tip>
+
+## Property Attribute Filters
+
+Narrow by what the property **is** rather than what happened to it.
+
+| Flag | Unit |
+|---|---|
+| `--property-type` | Repeatable or comma-separated: `residential`, `commercial`, `industrial`, `agricultural`, `vacant land`, `exempt`, `miscellaneous`, `office`, `recreational` |
+| `--property-min-market-value` / `--property-max-market-value` | Integer **cents** (`50000000` = $500,000) |
+| `--property-min-lot-size` / `--property-max-lot-size` | Square feet |
+| `--property-min-building-area` / `--property-max-building-area` | Square feet |
+| `--property-min-unit-count` / `--property-max-unit-count` | Count |
+| `--property-min-year-built` / `--property-max-year-built` | Year (e.g. `1990`) |
+
+```bash
+# Older residential homes worth $500k-$1M with no solar permit
+shovels properties search --geo-id CA \
+  --permit-tags "-solar" \
+  --property-type residential \
+  --property-min-market-value 50000000 --property-max-market-value 100000000 \
+  --property-max-year-built 1989 \
+  --include-count --limit 10
+```
+
+<Warning>
+Attribute data covers roughly **60-70%** of properties, and a property with no value for an attribute never matches a range filter on it. Every attribute filter narrows results to the covered set — stacking several can empty a result that the same query returns rows for without them.
+</Warning>
+
+`story_count` is returned on every record but there is **no** `--property-*-story-count` filter; the Properties API has no story-count parameter. `permits search` does filter on story count.
+
+### Range validation
+
+Negative and inverted bounds are caught locally, before any API call or credit spend:
+
+```bash
+$ shovels properties search --geo-id 92024 --property-min-lot-size -5
+{"error":"--property-min-lot-size must not be negative, got -5","code":1,"error_type":"validation_error"}
+
+$ shovels properties search --geo-id 92024 \
+    --property-min-year-built 2000 --property-max-year-built 1990
+{"error":"--property-min-year-built (2000) must not exceed --property-max-year-built (1990)","code":1,"error_type":"validation_error"}
+```
+
+## Absence Searches
+
+Prefix a tag with `-` to find properties with **no** permit of that type on record. Every absence answer carries trust metadata scoring its reliability:
+
+```bash
+shovels properties search --geo-id 92024 --permit-tags "-solar" --limit 10
+```
+
+Absence is the highest-value property query and has its own article — see [CLI absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust).
+
+## properties get
+
+Fetch specific properties by address ID. Accepts 1-50 IDs as **positional arguments**, all in one request.
+
+```bash
+shovels properties get BJjCWAMtccQ DWe15mBxY8Y
+```
+
+<Info>
+ID is a positional argument, not a flag. `shovels properties get --id a_123` is wrong; `shovels properties get a_123` is right.
+</Info>
+
+A property's ID is its **address** geolocation ID — the same `id` returned by `properties search` and `addresses search`:
+
+```bash
+shovels properties get "$(shovels addresses search -q '1966 Olivenhain Rd, Encinitas CA' | jq -r '.data[0].geo_id')"
+```
+
+<Warning>
+`addresses search` exits `1` with `No addresses found.` when nothing matches, and the empty result then fails `properties get` with a decode error. In a script, check the resolved ID before passing it on.
+</Warning>
+
+### How get handles bad IDs
+
+The three failure modes are distinct, and only one of them is survivable:
+
+| Input | Behavior |
+|---|---|
+| Valid address ID with no property behind it | Row omitted from `data`, ID listed in `meta.missing`, exit `0` |
+| String that isn't a decodable address ID | **Whole request fails**, exit `1` |
+| City, county, or jurisdiction geo_id | **Whole request fails**, exit `1` |
+
+```bash
+$ shovels properties get BJjCWAMtccQ BJjCWAMtccX
+{"data":[{"id":"BJjCWAMtccQ", "...": "..."}],"meta":{"count":1,"missing":["BJjCWAMtccX"],"credits_used":1}}
+```
+
+`meta.missing` is absent entirely when every requested ID resolved. But one undecodable ID takes down the whole batch:
+
+```bash
+$ shovels properties get BJjCWAMtccQ NOT_A_REAL_ID
+{"error":"...Could not decode property id 'NOT_A_REAL_ID' at position 2. Each id must be an ADDRESS geolocation id...","code":1,"error_type":"validation_error"}
+```
+
+<Warning>
+Validate IDs before batching 50 of them. A single malformed ID costs you the entire request, while a merely-unknown ID costs you nothing.
+</Warning>
+
+Trust metadata is a **search-only** surface: rows returned by `properties get` carry no `trust` object, even though the generated schema lists the fields.
+
+## Response Fields
+
+`shovels schema properties search` prints all 45 response fields offline, with types and units, and needs no API key. The rollup fields are the ones with no equivalent in `permits search`:
+
+| Field | Description |
+|---|---|
+| `permit_count` / `untagged_permit_count` | Permits linked to the address; how many carry no canonical tag |
+| `tags` / `statuses` | Distinct canonical tags and permit statuses across the address's permits |
+| `tag_tally` | Map of tag to permit count |
+| `tag_status_pairs` | Distinct `tag:status` pairs (status folds to `unknown` when null) |
+| `last_permit_date` | Latest permit start date across all permits; `null` when never permitted |
+| `last_date_by_tag` / `last_date_by_status` / `last_date_by_pair` | Latest permit date keyed by tag, by status, and by `tag:status` |
+| `last_unfinaled_date_by_tag` | Latest non-final permit date per tag |
+| `total_job_value` | Sum of job values across the property's permits, in **cents** |
+| `contractor_count` | Distinct contractors across the address's permits |
+| `apn` | Assessor parcel number — returned for mapping, **not searchable** |
+
+<Tip>
+`apn` is on every record so you can join into your own systems, but you can't search by it: APNs are county-specific, millions collide across counties, and roughly 30% of properties have none. Resolve the address to a `geo_id` instead.
+</Tip>
+
+## Dry Run
+
+Add `--dry-run` to print the resolved HTTP request without calling the API or spending credits — useful for confirming how flags map to query parameters:
+
+```bash
+$ shovels properties search --geo-id 92024 --permit-tags "-solar" --limit 10 --dry-run
+{
+  "method": "GET",
+  "url": "https://api.shovels.ai/v2/properties/search",
+  "params": { "geo_id": "92024", "permit_tags": ["-solar"], "size": 10 }
+}
+```
+
+## Related Articles
+
+- [CLI absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust) — Reading `trust` and `meta.trust_summaries`
+- [CLI commands overview](/docs/knowledge-base/cli/commands-overview) — Full list of commands and flags
+- [How to search for properties](/docs/knowledge-base/api/properties/property-search) — The same data via the REST API
+- [Properties vs Permits: which endpoint?](/docs/knowledge-base/api/properties/properties-vs-permits) — What properties deliberately won't answer
+- [Finding unfinaled permits](/docs/knowledge-base/api/properties/unfinaled-permits) — How "unfinaled" is determined

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -9,7 +9,7 @@ A comprehensive glossary of terms used throughout Shovels documentation, API, an
 ## A
 
 ### Absence Search
-A property search for the properties that have **no** permit of a given work type on record, written as a `-`-prefixed tag (e.g. `permit_tags=-solar`) on the Search Properties endpoint. Because a property can look permit-free due to data coverage rather than reality, every absence answer carries [trust fields](#trust-fields) scoring its reliability.
+A property search for the properties that have **no** permit of a given work type on record, written as a `-`-prefixed tag (e.g. `permit_tags=-solar` in the API, `--permit-tags "-solar"` in the CLI) on the Search Properties endpoint. Because a property can look permit-free due to data coverage rather than reality, every absence answer carries [trust fields](#trust-fields) scoring its reliability.
 
 ### Address ID
 A unique identifier assigned by Shovels to each distinct address in our database. The address ID remains consistent even if the address formatting varies across different permits, enabling you to link all permits at a single property.
@@ -46,7 +46,13 @@ An identifier linking multiple contractors that operate under the same parent or
 ### CLI Config File
 A YAML configuration file at `~/.config/shovels/config.yaml` that stores persistent CLI settings like your API key and default preferences. Created with `shovels config set`.
 
+### Coverage Tier
+A permit coverage bucket for a jurisdiction—`high`, `medium`, or `low`—reported on every [absence search](#absence-search) row as `trust.coverage_tier`. Higher tiers mean a "no permit on record" answer is more trustworthy for that area.
+
 ## D
+
+### Data Horizon
+The most recent date past which "no permit since D" is under-observed for a given row (`trust.data_horizon`). If your `permit_from` / `--permit-from` is later than the horizon, the absence answer is a guess about data that hasn't arrived yet. Never null.
 
 ### Decision (Shovels Decision)
 A structured record of a municipal zoning or land use decision extracted from city council and planning department meetings. Decisions capture rezoning approvals, special use permits, variances, and zoning code modifications—often months before permits are filed.
@@ -63,6 +69,9 @@ A unique identifier assigned by Shovels to each decision record (`id` in the API
 ### Deduplication
 The process of identifying and consolidating duplicate records. Shovels deduplicates permits (maintaining one record per permit even with status updates) and contractors (linking related business entities).
 
+### --dry-run
+A CLI flag that prints the resolved HTTP request as JSON—method, URL, and query parameters—without calling the API or consuming credits. Useful for confirming how flags map to API parameters before spending anything.
+
 ## E
 
 ### EDL (Enterprise Data License)
@@ -70,6 +79,9 @@ Shovels' bulk data product for enterprise customers. EDL delivers complete datas
 
 ### Exit Code (CLI)
 A numeric status code returned when a CLI command completes. Used by scripts and AI agents to determine success (0) or error type (1-5): client error, auth error, rate limited, credits exhausted, or server error.
+
+### Expected Miss Rate
+The headline trust number on an [absence search](#absence-search): the estimated probability that a returned "no permit on record" answer is wrong because the permit hasn't arrived yet. Reported per API page as `trust_summary.expected_miss_rate`, and in the CLI inside each entry of the [`meta.trust_summaries`](/docs/knowledge-base/cli/absence-and-trust) array.
 
 ## F
 
@@ -117,6 +129,9 @@ The geographic area governed by a specific AHJ. Shovels covers approximately 2,0
 
 ## L
 
+### Legal Owner
+The recorded owner of a property (`legal_owner`), matched on its canonical form so casing variants collapse together. The only Properties filter that works nationwide with no location: pass up to 10 owner names to retrieve a portfolio across the US.
+
 ### --limit all
 A CLI flag that fetches all available records instead of the default 50-record limit. Automatically handles pagination with an upper bound set by `--max-records` (default: 10,000, max: 100,000).
 
@@ -157,7 +172,7 @@ The most frequently used email address across all permits for a given contractor
 The most frequently used phone number across all permits for a given contractor.
 
 ### Property ID
-The unique identifier of a property in the Shovels Properties API—the same identifier as the property's address ID. Use it with the Get Properties By ID endpoint to retrieve up to 50 property records per call.
+The unique identifier of a property in the Shovels Properties API—the same identifier as the property's address ID. Use it with the Get Properties By ID endpoint, or `shovels properties get`, to retrieve up to 50 property records per call.
 
 ### PUD (Planned Unit Development)
 A flexible zoning classification for master-planned projects that allows developers to negotiate custom development standards. PUDs often appear as a subcategory in Shovels Decision data.
@@ -172,6 +187,9 @@ A technical limit on how quickly you can make API requests. Rate limits protect 
 
 ## S
 
+### Schema Command (CLI)
+`shovels schema [command-path]` prints the annotated JSON response schema for any data command—field types, descriptions, units, ranges, enums, a jq-ready `field_index`, and the flag-to-parameter map. Runs entirely offline with no API key and no credit cost. Any data command also accepts `--schema` to print its own.
+
 ### SIC (Standard Industrial Classification)
 An older industry classification system used to categorize businesses. More widely adopted than NAICS codes. Available in Shovels contractor data.
 
@@ -179,7 +197,7 @@ An older industry classification system used to categorize businesses. More wide
 Permission granted by a municipality to conduct a specific activity that isn't automatically allowed in a zone but may be approved with conditions. Also called conditional use permits in some jurisdictions. Special use permits often precede specific business or development activity at a known location.
 
 ### Shovels CLI
-A single-binary command-line tool for querying U.S. building permit and contractor data. Outputs JSON to stdout and handles pagination, rate limits, and credit tracking automatically. No runtime dependencies required.
+A single-binary command-line tool for querying U.S. building permit, property, contractor, and decision data. Outputs JSON to stdout and handles pagination, rate limits, and credit tracking automatically. No runtime dependencies required.
 
 ### Shovels Online
 The web-based application for searching and downloading permit and contractor data. Access at [app.shovels.ai](https://app.shovels.ai).
@@ -190,21 +208,30 @@ A zoning change applied to a specific property or small group of parcels, typica
 ### Start Date
 The first date recorded for a permit in Shovels' system. Generated by Shovels based on collected permit data.
 
+### Suppressed Scopes
+The count of coverage scopes removed from an [absence search](#absence-search) result (`suppressed_scopes`). Where coverage for a work type in an area is too thin to answer honestly, those properties are dropped entirely rather than returned as false negatives—so a low-coverage area can legitimately return few or no absence rows.
+
 ## T
 
 ### Tags
 Shovels-assigned categories that classify permits by work type (e.g., solar, HVAC, electrical, roofing). Use the `/list/tags` endpoint to get valid tag values.
 
 ### Trust Fields
-Confidence metadata attached to every [absence search](#absence-search) answer in the Properties API. Per row: coverage tier, unresolved rate, and data horizon. Per page: `expected_miss_rate`, the estimated probability that a returned "no permit on record" answer is wrong because the permit hasn't arrived yet. See [Absence search](/docs/knowledge-base/api/properties/absence-queries).
+Confidence metadata attached to every [absence search](#absence-search) answer in the Properties API. Per row: [coverage tier](#coverage-tier), [unresolved rate](#unresolved-rate), [data horizon](#data-horizon), the jurisdiction-join basis and its error bar, and row-level flags. Per page: [`expected_miss_rate`](#expected-miss-rate) and [`suppressed_scopes`](#suppressed-scopes). See [Absence search](/docs/knowledge-base/api/properties/absence-queries).
+
+### trust_summaries
+A CLI-only `meta` array carrying one trust summary per API page fetched, in fetch order. Because `--limit` merges pages and each page's rates are row-weighted over its own rows, no single summary is correct for a merged result—so the CLI reports them unaggregated rather than inventing a combined figure. Omitted entirely when a query has no absence filter. See [CLI absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust).
 
 ## U
 
 ### Unfinaled Permit
-A permit that was pulled but never finaled, determined from permit **status** rather than dates: a work type is unfinaled at a property when its latest non-final permit is more recent than its latest final permit of that type. Searchable via `permit_tags_unfinaled` on the Search Properties endpoint.
+A permit that was pulled but never finaled, determined from permit **status** rather than dates: a work type is unfinaled at a property when its latest non-final permit is more recent than its latest final permit of that type. Searchable via `permit_tags_unfinaled` on the Search Properties endpoint, or `--permit-tags-unfinaled` in the CLI.
 
 ### Unknown (Permit Status)
 A permit status indicating insufficient data to determine the current state. May result from incomplete jurisdiction records or missing date information.
+
+### Unresolved Rate
+The share (0-1) of a jurisdiction's permits of a given work type that never linked to an address (`trust.unresolved_rate`). A high unresolved rate means permits of that type exist in the area but can't be attributed to specific properties, weakening any "no permit on record" claim.
 
 ### Upzoning
 A zoning change that increases the allowed development intensity of a property or area—for example, permitting higher density or taller buildings. Upzonings can raise land values before any construction begins.

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -72,7 +72,28 @@ The CLI wraps the Shovels REST API but handles authentication headers, cursor pa
 Use `--limit all`. The CLI automatically handles pagination and fetches up to 10,000 records by default (configurable with `--max-records`).
 
 ### What commands are available?
-Main commands: `permits search`, `permits get`, `contractors search`, `contractors get`, `contractors permits`, `contractors employees`, `contractors metrics`, `addresses search`, `cities search`, `tags list`, `usage`, `config`. Run `shovels --help` for full list.
+Main commands: `permits search`, `permits get`, `properties search`, `properties get`, `contractors search`, `contractors get`, `contractors permits`, `contractors employees`, `contractors metrics`, `decisions search`, `decisions get`, `addresses search`, `cities search`, `tags list`, `schema`, `usage`, `config`. Run `shovels --help` for full list.
+
+### How do I query properties from the CLI?
+Use `shovels properties search` (added in v0.8.0). It needs `--geo-id`, `--legal-owner`, or both — not both a geo and a date range like `permits search`. Example: `shovels properties search --geo-id 92024 --permit-tags "-solar" --limit 10`. See [Querying properties from the CLI](/docs/knowledge-base/cli/properties).
+
+### How do I find properties with no permit of a given type in the CLI?
+Prefix the tag with `-` inside `--permit-tags`: `--permit-tags "-solar"`. Combine presence and absence in one value, e.g. `--permit-tags "roofing,-solar"`. Every absence row carries a `trust` object. See [Absence searches and trust fields](/docs/knowledge-base/cli/absence-and-trust).
+
+### Why does my properties result have several trust_summaries?
+Because each entry covers one API page. `--limit 205` fetches three pages, so you get three summaries. The CLI deliberately doesn't merge them — each rate is row-weighted over its own page, so averaging them would be wrong. Read the worst page instead: `jq '[.meta.trust_summaries[].expected_miss_rate] | max'`.
+
+### Why is there no --permit-to on properties search?
+A property record keeps only the latest permit date per work type, so a closed date window can't be answered correctly. Only "ever" and "since date D" (`--permit-from`) are expressible. Use `shovels permits search` for date windows.
+
+### How do I search one owner's properties nationwide?
+`shovels properties search --legal-owner "INVITATION HOMES"` — no `--geo-id` needed. Repeat the flag for up to 10 owners; values are never split on commas, so `"SMITH, JOHN"` stays one owner.
+
+### Why did properties get fail when only one ID was bad?
+An ID that's well-formed but unknown is fine — it's omitted and listed in `meta.missing` with exit `0`. But an ID that can't be decoded as an address ID, or a city/county/jurisdiction geo_id, fails the whole request with exit `1`. Validate before batching 50.
+
+### How do I see a command's response fields without spending credits?
+`shovels schema properties search` prints every field with its type, unit, and description, plus a jq-ready `field_index`. It runs offline and needs no API key. `--dry-run` similarly prints the resolved HTTP request without calling the API.
 
 ### Can I use the CLI with scripts and AI agents?
 Yes. The CLI outputs JSON to stdout and errors to stderr with meaningful exit codes (0=success, 1=client error, 2=auth error, 3=rate limited, 4=credits exhausted, 5=server error). Perfect for piping to `jq` or scripting.
@@ -137,6 +158,15 @@ Yes—`legal_owner` is the one filter that works nationwide with no location. Pa
 
 ### Can I search properties by parcel number (APN)?
 No. APN is returned on every record for mapping into your own systems, but it's not searchable: APNs are county-specific, millions collide across counties, and about 30% of properties have none.
+
+### Can I search properties by jurisdiction?
+No. Jurisdiction is recorded on only a minority of property records, so scoping to it would silently drop properties that were never permitted. Jurisdiction geo_ids are rejected — scope by city, county, state, ZIP, or address instead.
+
+### Why do my property attribute filters return nothing?
+Attribute data (value, size, year, units, type) covers roughly 60-70% of properties, and a property with no value for an attribute never matches a range filter on it. Stacking several filters can empty a result that returns plenty of rows without them. Loosen or drop one filter at a time.
+
+### Can I query properties from the CLI?
+Yes, as of CLI v0.8.0: `shovels properties search` and `shovels properties get`. See [Querying properties from the CLI](/docs/knowledge-base/cli/properties).
 
 ---
 

--- a/mint.json
+++ b/mint.json
@@ -256,6 +256,8 @@
             "docs/knowledge-base/cli/installation",
             "docs/knowledge-base/cli/authentication",
             "docs/knowledge-base/cli/commands-overview",
+            "docs/knowledge-base/cli/properties",
+            "docs/knowledge-base/cli/absence-and-trust",
             "docs/knowledge-base/cli/output-and-pagination",
             "docs/knowledge-base/cli/error-codes",
             "docs/knowledge-base/cli/scripting-and-agents"


### PR DESCRIPTION
Adds knowledge base coverage for the `properties` command group introduced in [shovels-cli v0.8.0](https://github.com/ShovelsAI/shovels-cli/releases/tag/v0.8.0), and corrects four pre-existing documentation errors surfaced while verifying it.

Linear: MAR-257

## New articles

| Article | Covers |
|---|---|
| `cli/properties.mdx` | Command group, `--geo-id`/`--legal-owner` scope rule, permit and attribute filters, `properties get` ID semantics, response rollup fields, `--dry-run` |
| `cli/absence-and-trust.mdx` | Absence searches, the per-row `trust` object, and the per-page `meta.trust_summaries` array |

Absence gets its own article because it is where CLI output diverges structurally from the REST API. The API returns one `trust_summary` per page, scoped to that page's rows. Since `--limit` merges pages, the CLI collects them into an **unaggregated array** — averaging row-weighted rates across pages of unequal size would be wrong, and the CLI has no basis to re-derive a correct merged figure. Verified: `--limit 205` returns 3 pages (100 + 100 + 5) and 3 summaries. The key is omitted entirely on presence-only queries.

## Corrections

1. **`output-and-pagination.mdx` documented a response shape that does not exist.** It showed `get` commands returning `data` as a single object when called with one ID. `data` is always an array — confirmed on both `properties get` and `permits get`. Anyone who wrote `jq '.data.id'` from that example has broken code. Section removed.
2. **`absence-queries.mdx` was missing two production trust fields**: `trust_jurisdiction_basis` and `trust_jurisdiction_error_bar` (the 6.13% ZIP-dominant estimate error), plus the `untagged_permits_present` row flag.
3. **`properties-by-id.mdx` said unknown IDs are "simply omitted."** Only partly true, and the difference matters: a *decodable* unknown ID lands in `meta.missing` with exit 0, but an *undecodable* ID — or a city/county/jurisdiction geo_id — fails the entire batch with exit 1.
4. **`installation.mdx` listed bare binary assets** (`shovels-darwin-arm64`). Releases ship as `.tar.gz`/`.zip`, so the documented download and checksum commands resolved to URLs that 404.

## Scope note for reviewers

`commands-overview.mdx` bills itself as a complete overview but was missing `decisions` (v0.7.0) and `schema`/`coverage`/`states`/`zipcodes` plus the `--dry-run`/`--schema` global flags (all v0.3.0). I added them rather than leave known-wrong content in a file I was already editing. Happy to strip that back to properties-only if you'd rather keep this PR narrow.

Two of its examples were also wrong and are fixed: `cities coverage` takes the geo_id positionally and requires a date range, and `states search` matches only the two-letter abbreviation.

## Verification

Installed v0.8.0 and ran every command and jq snippet in these articles against the live API (221 credits). Local validation errors, both `trust_summaries` behaviors, mixed presence+absence queries, owner-nationwide search, unfinaled search, and the `get` missing/malformed-ID paths were all confirmed against real output rather than inferred from source. Internal doc links and glossary anchors were checked programmatically.

## Two CLI bugs found

Filed separately against the CLI repo, not addressed here:

- `--permit-tags` silently discards all but the last value when repeated (it's a `String`, not a `StringSlice`), so `--permit-tags solar --permit-tags roofing` searches roofing alone with no error. Documented as a footgun for now.
- `states search --help` advertises `-q "Cal"` and `"California"`, but only the two-letter code matches.