### PR TITLE
Ignore macOS cruft and local Claude Code state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 venv
 .vscode
+.DS_Store
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Adds three entries to `.gitignore`. No tracked files are affected, so no history rewrite or `git rm --cached` is needed.

```
.DS_Store
.claude/settings.local.json
.claude/worktrees/
```

## Why

Four stray `.DS_Store` files sat unignored (repo root, `docs/`, `docs/knowledge-base/`, `docs/knowledge-base/data/`). They cluttered every `git status` and were one `git add -A` away from being committed.

## Why the Claude Code entries are scoped, not blanket

Ignoring `.claude/` wholesale would have been wrong — the directory mixes shared and personal state:

| Path | Contents | Decision |
|---|---|---|
| `.claude/settings.json` | Just `enabledPlugins` — shared project config | **Left committable** |
| `.claude/settings.local.json` | ~45-entry per-machine permission allowlist with absolute local paths | Ignored |
| `.claude/worktrees/` | Transient scratch checkouts | Ignored |

So a teammate can still commit `settings.json` to share plugin config, while nobody's personal allowlist or scratch worktrees leak into the repo.

## Verification

`git check-ignore` confirms all six intended paths are ignored and `settings.json` is not:

```
.DS_Store                                    ignored
docs/.DS_Store                               ignored
docs/knowledge-base/.DS_Store                ignored
docs/knowledge-base/data/.DS_Store           ignored
.claude/settings.local.json                  ignored
.claude/worktrees/agitated-lamport-4a7acf    ignored
.claude/settings.json                        committable
```

`git ls-files | grep -c DS_Store` and the same for `^\.claude/` both return `0`, so nothing currently tracked changes behavior.

The existing `venv` and `.vscode` entries are untouched — the diff is purely additive.

## Note

`.claude/` will still appear in `git status` because the unignored `settings.json` lives inside it. That's intentional. If the team would rather keep the whole directory out of git, broaden the rule to `.claude/` and drop the two scoped lines.