### PR TITLE
Correct properties permit filters to repeated keys

### DIFF
--- a/docs/knowledge-base/api/properties/absence-queries.mdx
+++ b/docs/knowledge-base/api/properties/absence-queries.mdx
@@ -19,7 +19,7 @@ curl -X GET \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
-This returns properties with no resolved solar permit on record. You can combine absence with other filters—for example `permit_tags=roofing,-solar` finds properties with a roofing permit but no solar permit.
+This returns properties with no resolved solar permit on record. You can combine absence with other filters by repeating the key—for example `permit_tags=roofing&permit_tags=-solar` finds properties with a roofing permit but no solar permit. A comma-joined value like `permit_tags=roofing,-solar` is rejected with a [422](/docs/knowledge-base/api/errors/422-error).
 
 Adding `permit_from` changes the meaning:
 

--- a/docs/knowledge-base/api/properties/property-search.mdx
+++ b/docs/knowledge-base/api/properties/property-search.mdx
@@ -34,10 +34,16 @@ To turn a typed address into a `geo_id`, call [Search Addresses](/api-reference/
 
 | Filter | Description |
 |--------|-------------|
-| `permit_tags` | Comma-separated canonical tags. A positive tag keeps properties with that work type on some permit; a `-` prefix (e.g. `-solar`) keeps properties with **no** permit of that type on record—see [Absence search](/docs/knowledge-base/api/properties/absence-queries) |
-| `permit_status` | Comma-separated statuses (`final`, `in_review`, `inactive`, `active`). Combined with positive tags, the tag and status must appear on the same permit |
+| `permit_tags` | Canonical tags, one key per tag (`?permit_tags=roofing&permit_tags=-solar`). A positive tag keeps properties with that work type on some permit; a `-` prefix (e.g. `-solar`) keeps properties with **no** permit of that type on record—see [Absence search](/docs/knowledge-base/api/properties/absence-queries). Several positive tags require **every** tag, but not all on the same permit—matching is at address grain, a deliberate divergence from [Search Permits](/api-reference/permits/search-permits) |
+| `permit_status` | Statuses, one key per status (`?permit_status=final&permit_status=active`): `final`, `in_review`, `inactive`, `active`. On its own it keeps properties with a permit in any of the named statuses; combined with positive tags, the tag and status must appear on the same permit. `unknown` is not filterable |
 | `permit_from` | ISO date (`YYYY-MM-DD`). Positive filters match since this date; a pure-absence exclusion means "none since this date" |
-| `permit_tags_unfinaled` | Keeps properties with an unfinaled permit of each named tag—see [Unfinaled permits](/docs/knowledge-base/api/properties/unfinaled-permits) |
+| `permit_tags_unfinaled` | Keeps properties with an unfinaled permit of each named tag, one key per tag—see [Unfinaled permits](/docs/knowledge-base/api/properties/unfinaled-permits) |
+
+<Warning>
+These three filters take **repeated keys**, not one comma-joined value. `permit_tags=solar,-roofing` is rejected with a [422](/docs/knowledge-base/api/errors/422-error) naming the bad token—send `permit_tags=solar&permit_tags=-roofing` instead.
+
+An unrecognized tag is also a 422 rather than an empty result, so a typo fails loudly here. [Search Permits](/api-reference/permits/search-permits) returns 200 with zero items for the same typo, which is easy to misread as "no such properties."
+</Warning>
 
 <Warning>
 `permit_to` (and any other upper date bound) is **not supported** on properties. The property record keeps only the latest permit date per work type, so a closed date window can't be answered correctly. Use [Search Permits](/api-reference/permits/search-permits) for date-window queries.

--- a/docs/knowledge-base/api/properties/unfinaled-permits.mdx
+++ b/docs/knowledge-base/api/properties/unfinaled-permits.mdx
@@ -11,7 +11,7 @@ Properties are currently in **beta**. Query parameters and response fields may s
 
 ## Usage
 
-Pass one or more canonical tags, comma-separated. Each named tag must have an unfinaled permit at the property:
+Pass one or more canonical tags, one key per tag (`?permit_tags_unfinaled=solar&permit_tags_unfinaled=roofing`). Each named tag must have an unfinaled permit at the property:
 
 ```bash
 curl -X GET \

--- a/docs/knowledge-base/cli/commands-overview.mdx
+++ b/docs/knowledge-base/cli/commands-overview.mdx
@@ -49,7 +49,7 @@ shovels properties search \
 ```
 
 <Info>
-Properties are in **beta**. Unlike `permits search`, there is no `--permit-to` flag and jurisdiction geo_ids are rejected. Tags are passed as one comma-separated value rather than a repeatable flag. See [Querying properties from the CLI](/docs/knowledge-base/cli/properties).
+Properties are in **beta**. Unlike `permits search`, there is no `--permit-to` flag and jurisdiction geo_ids are rejected. See [Querying properties from the CLI](/docs/knowledge-base/cli/properties).
 </Info>
 
 ### contractors
@@ -179,11 +179,12 @@ shovels version
 
 ## Common Search Filters
 
-These flags are available on `permits search` and `contractors search`. `properties search` uses a different flag shape — see [Querying properties from the CLI](/docs/knowledge-base/cli/properties):
+These flags are available on `permits search` and `contractors search`. `properties search` names and scopes several of them differently — see [Querying properties from the CLI](/docs/knowledge-base/cli/properties):
 
 | Difference | `permits` / `contractors` | `properties` |
 |---|---|---|
-| Tag flag | `--tags`, repeatable or comma-separated | `--permit-tags`, one comma-separated value only — repeating it silently keeps just the last |
+| Tag flag | `--tags`, repeatable or comma-separated | `--permit-tags`, same shape. Multiple positive tags match at address grain, not on one shared permit |
+| Unknown tag | Returns zero rows | Rejected with a 422 naming the tag |
 | Date range | `--permit-from` **and** `--permit-to`, both required | `--permit-from` only; no upper bound exists |
 | Scope | `--geo-id` required | `--geo-id` **or** `--legal-owner` |
 | Attribute prefix | `--min-market-value` | `--property-min-market-value` |

--- a/docs/knowledge-base/cli/installation.mdx
+++ b/docs/knowledge-base/cli/installation.mdx
@@ -22,7 +22,7 @@ The binary installs to `~/.shovels/bin` by default.
 | Linux | amd64 | `shovels_<version>_linux_amd64.tar.gz` |
 | Windows | amd64 | `shovels_<version>_windows_amd64.zip` |
 
-Releases ship as compressed archives containing the `shovels` binary — for example `shovels_0.8.0_darwin_arm64.tar.gz`.
+Releases ship as compressed archives containing the `shovels` binary — for example `shovels_0.8.3_darwin_arm64.tar.gz`.
 
 ## Install Script Options
 
@@ -46,10 +46,10 @@ Download binaries directly from [GitHub Releases](https://github.com/ShovelsAI/s
 
 ```bash
 # Example: download and verify on macOS arm64
-curl -LO https://github.com/ShovelsAI/shovels-cli/releases/download/v0.8.0/shovels_0.8.0_darwin_arm64.tar.gz
-curl -LO https://github.com/ShovelsAI/shovels-cli/releases/download/v0.8.0/checksums.txt
+curl -LO https://github.com/ShovelsAI/shovels-cli/releases/download/v0.8.3/shovels_0.8.3_darwin_arm64.tar.gz
+curl -LO https://github.com/ShovelsAI/shovels-cli/releases/download/v0.8.3/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
-tar -xzf shovels_0.8.0_darwin_arm64.tar.gz
+tar -xzf shovels_0.8.3_darwin_arm64.tar.gz
 chmod +x shovels
 mv shovels /usr/local/bin/shovels
 ```

--- a/docs/knowledge-base/cli/properties.mdx
+++ b/docs/knowledge-base/cli/properties.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Properties"
 
 **The `properties` command group returns one row per property, with that property's permit history already rolled up onto the record.** A single row answers "what has happened at this address" — permit counts, work-type tags, latest activity dates, contractors, job values, and property attributes.
 
-Added in CLI **v0.8.0**. Run `shovels version` to check yours; upgrade with `curl -LsSf https://shovels.ai/install.sh | sh`.
+Added in CLI **v0.8.0**; **v0.8.1** or newer is required for the permit filters below. Run `shovels version` to check yours; upgrade with `curl -LsSf https://shovels.ai/install.sh | sh`.
 
 <Info>
 Properties are currently in **beta**. Query parameters, response fields, and the absence-trust surface may still change. Treat the response shape as unstable.
@@ -83,29 +83,29 @@ shovels properties search --legal-owner "INVITATION HOMES" --include-count --lim
 
 | Flag | Description |
 |---|---|
-| `--permit-tags` | Canonical tags as **one comma-separated value** (e.g. `"solar,-roofing"`). A bare tag keeps properties that have it; a `-` prefix keeps properties **without** it |
-| `--permit-status` | One comma-separated value: `final`, `in_review`, `inactive`, `active` |
+| `--permit-tags` | Canonical tags — repeat the flag or comma-separate (e.g. `--permit-tags solar --permit-tags "-roofing"`, or `--permit-tags "solar,-roofing"`). A bare tag keeps properties that have it; a `-` prefix keeps properties **without** it. Several positive tags require **every** tag, though not all on the same permit |
+| `--permit-status` | Repeat the flag or comma-separate: `final`, `in_review`, `inactive`, `active`. An invalid status is caught locally, before any API call |
 | `--permit-from` | Binds the tag, status, and absence filters to this date (`YYYY-MM-DD`) |
-| `--permit-tags-unfinaled` | Keeps properties with an **unfinaled** permit of each named tag |
+| `--permit-tags-unfinaled` | Keeps properties with an **unfinaled** permit of each named tag — repeat the flag or comma-separate |
 
 <Warning>
 **There is no `--permit-to` flag.** A property record keeps only the latest permit date per work type, so a closed date window can't be answered correctly. Passing it fails as an unknown flag. Use `shovels permits search` for date windows and upper bounds.
 </Warning>
 
-Note the flag-shape difference from `permits search`: properties takes tags as a single comma-separated string, where `permits search` uses a repeatable `--tags`.
+<Tip>
+An unrecognized tag is an **error**, not an empty result: the API returns a 422 naming the bad tag. Run `shovels tags list --limit all` for the canonical set. `permits search` behaves differently — it returns zero rows for an unknown tag, which is easy to misread as "no such permits."
+</Tip>
 
-<Warning>
-`--permit-tags` is a single value, so **repeating it silently keeps only the last one**. `--permit-tags solar --permit-tags roofing` searches for `roofing` alone, with no error. Write `--permit-tags "solar,roofing"` instead.
-
-`--property-type` is different — it accepts both repetition and a comma-separated value, and both forms keep every value.
-</Warning>
-
-Use `--dry-run` to confirm what your flags actually resolved to:
+Both forms produce the same request. Use `--dry-run` to confirm what your flags resolved to:
 
 ```bash
 $ shovels properties search --geo-id 92024 --permit-tags solar --permit-tags roofing --dry-run
-{"method":"GET","url":"...","params":{"geo_id":"92024","permit_tags":["roofing"],"size":50}}
+{"method":"GET","url":"...","params":{"geo_id":"92024","permit_tags":["solar","roofing"],"size":50}}
 ```
+
+<Info>
+These three filters need CLI **v0.8.1** or newer. In v0.8.0 they were single-valued: repeating one silently kept just the last value, and the comma-separated form it documented now fails against the current API. Run `shovels version` and upgrade if you are below 0.8.1.
+</Info>
 
 ### Finding unfinaled work
 


### PR DESCRIPTION
Docs follow-up to [ENG-4040](https://linear.app/shovels/issue/ENG-4040/cli-repeated-permit-tags-silently-drops-all-but-the-last-value), tracked in [MAR-261](https://linear.app/shovels/issue/MAR-261/update-properties-permit-filter-docs-for-repeated-key-shape).

`/properties/search` now takes `permit_tags`, `permit_status`, and `permit_tags_unfinaled` as **repeated query keys** and rejects a comma-joined value with a 422. The knowledge base documented the old shape, so the API examples were failing outright.

Verified against the published production spec (`api.shovels.ai/spec/v2/openapi.production.yaml`), where all three params are `type: array`.

## API pages — examples were broken

- `api/properties/property-search.mdx` — filter table said "comma-separated" for tags and status
- `api/properties/absence-queries.mdx` — the `permit_tags=roofing,-solar` example is a 422
- `api/properties/unfinaled-permits.mdx` — "Pass one or more canonical tags, comma-separated"

## CLI pages

CLI v0.8.1 ([shovels-cli#17](https://github.com/ShovelsAI/shovels-cli/pull/17)) made the matching flags `StringSlice`, so repetition combines instead of keeping only the last value. The comma form still works CLI-side because pflag splits on commas — only the raw API rejects it.

- `cli/properties.mdx` — removed the "repeating it silently keeps only the last one" warning and the `--dry-run` example built to demonstrate the dropped value; added the v0.8.1 floor
- `cli/commands-overview.mdx` — dropped the tag-shape divergence from the Info block and the comparison table
- `cli/installation.mdx` — manual-download examples pinned v0.8.0, which cannot express a multi-tag properties filter in either flag form against the current API. Moved to v0.8.3.

## Behavior newly documented

Three things the endpoint documents that the knowledge base never stated:

- Several positive tags require **every** tag, matched at **address grain** rather than on one shared permit — an explicit divergence from `/permits/search`
- An unrecognized tag is a 422 naming it, where `/permits/search` returns 200 with zero items for the same typo
- `unknown` is not a filterable `permit_status`

## Deliberately not included

The `states search` caveat in `cli/commands-overview.mdx` stays as-is. [ENG-4041](https://linear.app/shovels/issue/ENG-4041/cli-states-search-help-advertises-name-matching-that-returns-nothing) is marked Done, but production still returns zero rows for every full-name query, so the caveat is accurate for users today. Tracked in [MAR-262](https://linear.app/shovels/issue/MAR-262/remove-states-search-abbreviation-only-caveat-when-eng-4041-deploys) behind a re-verification gate.

## Testing

`mintlify broken-links` could not run locally (node 26; Mintlify requires LTS). Introduced link targets were checked by hand against existing usage, and callout tags verified balanced. Worth a look at the Mintlify preview build on this PR.