### PR TITLE
Fix KB credit reset wording and repoint EDL link

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -23,7 +23,7 @@ If you have a question that isn't answered by our range of tutorials, how-to wal
   Leverage our best-in-industry API, which is ready for direct product integration or programmatic data wrangling.
 </Card>
 
-<Card title="Shovels EDL (Enterprise Data License)" icon="database" horizontal="true" href="https://www.shovels.ai/data-feed">
+<Card title="Shovels EDL (Enterprise Data License)" icon="database" horizontal="true" href="https://www.shovels.ai/solutions/data-feed">
   Let your data science team loose with the entirety of the Shovels datasets, which ranges from Permits to Contractors to Properties to Demographics, nationwide.
 </Card>
 

--- a/docs/knowledge-base/api/basics/request-counts.mdx
+++ b/docs/knowledge-base/api/basics/request-counts.mdx
@@ -72,7 +72,7 @@ Every API response includes credit tracking headers:
 You can also view credit usage in the **Profile Settings** section of your account at [app.shovels.ai](https://app.shovels.ai/profile-settings/).
 
 <Info>
-Credits operate on a **30-day rolling window**. Your usage resets based on when credits were consumed, not on a fixed calendar date.
+Credits reset monthly on your subscription or upgrade date.
 </Info>
 
 ## Related Articles


### PR DESCRIPTION
Wave 1 of the post-launch KB refresh (MAR-267) — the two changes with a fully confirmed source of truth, no product-launch dependency.

**Changes**
- `request-counts.mdx`: credit reset now reads *"resets monthly on your subscription or upgrade date"* (was "30-day rolling window"), matching the launched pricing page (the definitive credit model).
- `introduction.mdx`: EDL card repointed `/data-feed` → `/solutions/data-feed` (refreshed site IA).

**Validation:** `mintlify broken-links` — these edits introduce no broken links (the pre-existing `/api-reference` flags are unrelated).

Linear: MAR-267. Reviewer: @rbucks — merge when ready.