### PR TITLE
Align KB pricing article to launched plan lineup

### DIFF
--- a/docs/knowledge-base/getting-started/pricing-structure.mdx
+++ b/docs/knowledge-base/getting-started/pricing-structure.mdx
@@ -1,13 +1,22 @@
 ---
 title: "How Much Does Shovels Cost?"
-description: "Shovels offers free trials, paid Online/API plans (see app.shovels.ai), and custom Enterprise Data License (EDL) pricing. Contact sales for EDL quotes."
+description: "Shovels Online and the API share credit-based plans—Free, Basic, Pro, and Enterprise. See current prices at shovels.ai/pricing; Enterprise Data License (EDL) pricing is custom."
 ---
 
-**Shovels pricing starts with a free tier. View current Online and API plans at [app.shovels.ai](https://app.shovels.ai). Enterprise Data License (EDL) pricing is custom—contact [sales@shovels.ai](mailto:sales@shovels.ai).** Choose Online for quick lookups, API for integrations, or EDL for bulk data analysis.
+**Shovels Online and the Shovels API share one credit-based plan lineup: Free, Basic, Pro, and Enterprise.** Choose Shovels Online for quick lookups, the API for integrations, or an Enterprise Data License (EDL) for bulk analysis. EDL pricing is custom—contact [sales@shovels.ai](mailto:sales@shovels.ai).
 
-## Shovels Online & API Pricing
+## Plans
 
-Shovels Online and API both have intro pricing tiers starting at $599/month. [Create an account or login](https://app.shovels.ai/) to see our latest pricing options.
+- **Free** — explore the data before you commit.
+- **Basic** — individuals and independent research.
+- **Pro** — small teams that need more credits and seats.
+- **Enterprise** — custom credits, seats, and support for larger organizations.
+
+For the current price, monthly credits, and seats on each plan, see [shovels.ai/pricing](https://www.shovels.ai/pricing), then [create an account or sign in](https://app.shovels.ai/) to subscribe.
+
+## How Credits Work
+
+Shovels plans are credit-based: one credit is one record returned. See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for how credits are counted and when they reset.
 
 ## Enterprise Data License (EDL)
 


### PR DESCRIPTION
Wave 1 of the post-launch KB refresh (MAR-267), batch 2.

Rewrites `pricing-structure.mdx` to match the launched pricing page using a **name-tiers-and-link** approach (agreed with Morgan) rather than hardcoding volatile prices:
- Names the plan lineup — **Free / Basic / Pro / Enterprise** — with a one-line 'best for' each (note: **Pro**, not the earlier draft's 'Team').
- Links to the canonical [shovels.ai/pricing](https://www.shovels.ai/pricing) for current price, credits, and seats — one source of truth, no drift.
- Adds a short 'How Credits Work' pointer to the API credits article.

Deliberately left for the Wave 2 credit pass (product-behavior, needs confirmation): free-tier '250 requests' vs '500 credits' wording in `free-trial-guide` and `cancel-subscription`, and the exports-cost-credits model.

**Validation:** `mintlify broken-links` clean for this file.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.