### PR TITLE
Repoint FAQ link to renamed troubleshooting page

### DIFF
--- a/docs/shovels-faq.mdx
+++ b/docs/shovels-faq.mdx
@@ -21,7 +21,7 @@ In order to view the next page of results in the map format, switch back to the 
 
 ### Why isn't a permit showing up, even though I know it exists?
 
-We talk about this issue in depth [here](/docs/online-troubleshooting#i-know-for-sure-that-a-permit-exists-why-cant-i-find-it), but the short of it is this:
+We talk about this issue in depth [here](/docs/shovels-online-troubleshooting#i-know-for-sure-that-a-permit-exists-why-cant-i-find-it), but the short of it is this:
 
 - There are over 20k permit jurisdictions nationwide, and we don't have access to all of them (though, this number includes an extremely long tail of small rural areas). 
 - When we do have a jurisdiction in our system, there are varying levels of permit and file digitization, which limits how much data we can process. 


### PR DESCRIPTION
Fixes a real broken deep link found during the KB refresh (MAR-267).

`shovels-faq.mdx` linked to `/docs/online-troubleshooting#…` (returns **404** — the article was renamed to `shovels-online-troubleshooting`). Repointed to `/docs/shovels-online-troubleshooting#…`; the target heading and anchor are unchanged and resolve **200**.

**Validation:** `mintlify broken-links` no longer flags this link. (The remaining `/api-reference` flags are false positives — those pages are generated from the OpenAPI spec and resolve 200 live.)

Linear: MAR-267. Reviewer: @rbucks — merge when ready.