### PR TITLE
Fix credit reset wording in the API articles

### DIFF
--- a/docs/knowledge-base/api/basics/api-key-access.mdx
+++ b/docs/knowledge-base/api/basics/api-key-access.mdx
@@ -30,7 +30,7 @@ During the free trial, each API call counts as **1 request**, regardless of how 
 
 ## Tracking Your Usage
 
-You can view your API credit usage on the **Manage subscription** tab of your account or by calling the `GET /v2/usage` endpoint. Credits operate on a 30-day rolling window.
+You can view your API credit usage on the **Manage subscription** tab of your account or by calling the `GET /v2/usage` endpoint. Credits reset monthly on your subscription or upgrade date.
 
 ## Need More Credits?
 

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -43,7 +43,7 @@ Search endpoints return up to **100 records per page** (default: 10) by setting 
 
 ## Tracking Your Usage
 
-Monitor your API usage on the **Manage subscription** tab of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
+Monitor your API usage on the **Manage subscription** tab of your account or via the `GET /v2/usage` endpoint. Credits reset monthly on your subscription or upgrade date.
 
 ## Need Higher Credit Limits?
 

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -102,7 +102,7 @@ curl -X GET "https://api.shovels.ai/v2/usage" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
-Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
+Credits reset monthly on your subscription or upgrade date.
 
 ### Response Types
 


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267) — opening the credit-model pass with the one edit that needs no product confirmation.

PR #45 corrected the credit reset window in `request-counts.mdx`. The same wrong sentence lives in three more articles; this finishes that change so the KB carries one wording.

**Changes**
- `api/basics/api-key-access.mdx`: *"Credits reset monthly on your subscription or upgrade date"* (was "Credits operate on a 30-day rolling window").
- `api/basics/credit-limits.mdx`: same sentence (was "a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date").
- `shovels-api-introduction.mdx`: same sentence, same prior wording. Outside the Knowledge Base tab, but the credit model is identical across interfaces and leaving one copy behind would reintroduce the contradiction.

Wording is copied verbatim from `request-counts.mdx` so the four articles are greppable as one string. `grep -rniE "30-day|rolling window" docs/ release-notes/` is now clean.

**Deliberately left for later PRs in this pass:** `api-key-access` and `credit-limits` both still carry the dead free-tier "250 requests" figure and the retired **Profile Settings** label. Those are separate changes with their own blast radius (9 and 6 sites respectively) and land next.

**Validation:** `mint broken-links` (4.2.3) — none of the three files are flagged. Remaining flags are the known `/api-reference` false positives (generated from the OpenAPI spec, resolve 200 live) plus one genuine pre-existing break in `foundations-building-blocks.mdx`, noted on the issue and untouched here.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.