### PR TITLE
Retire the request-based free tier model

### DIFF
--- a/docs/knowledge-base/api/basics/api-key-access.mdx
+++ b/docs/knowledge-base/api/basics/api-key-access.mdx
@@ -20,12 +20,12 @@ curl -X GET "https://api.shovels.ai/v2/meta/release" \
   -H "X-API-Key: YOUR_API_KEY_HERE"
 ```
 
-## Free Trial API Access
+## Free Plan API Access
 
-New accounts receive **250 free requests** to explore our capabilities before committing to a paid plan.
+New accounts start on the Free plan, with a monthly credit allowance to explore our capabilities before committing to a paid plan. See [shovels.ai/pricing](https://www.shovels.ai/pricing).
 
 <Info>
-During the free trial, each API call counts as **1 request**, regardless of how many records are returned. Paid plans use a credit-based system where each record returned counts against your credits.
+Every plan is credit-based: each record returned counts as one credit, on Free and paid plans alike.
 </Info>
 
 ## Tracking Your Usage

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -1,23 +1,23 @@
 ---
 title: "What is My API Credit Limit?"
-description: "Learn about Shovels API credit limits for paid plans, the free trial request system, and how to get higher limits for your needs."
+description: "Learn how Shovels API credit limits work on the Free plan and paid plans, and how to get a larger monthly credit allowance."
 ---
 
-**API credit limits apply to paid plans and control how many records you can retrieve.** Each record returned by the API counts against your credits. Contact sales for credit allocations tailored to your needs.
+**Your credit limit is the number of records you can retrieve each month, and every plan has one.** Each record returned by the API counts as one credit.
 
 <Info>
 **Credit limits vs. rate limits:** Credit limits track how many records you can consume based on your plan (a billing concept). Rate limits restrict how quickly you can make requests to protect system stability (a technical concept). This page covers credit limits. See [API Rate Limits](/docs/knowledge-base/api/basics/rate-limits) for rate limiting details.
 </Info>
 
-## Free Trial
+## Free Plan
 
-The API free trial provides **250 requests** with no time limit or credit card required. During the trial, each API call counts as **1 request regardless of how many records it returns**—so a search returning 100 permits still uses just 1 request.
+The Free plan provides **500 credits per month** with no time limit or credit card required. Credits are counted the same way on every plan: each record returned counts as one credit, so a search returning 100 permits uses 100 credits.
 
-If you need more requests during your trial, contact [sales@shovels.ai](mailto:sales@shovels.ai) for an extension.
+If you need a larger allowance, see [shovels.ai/pricing](https://www.shovels.ai/pricing).
 
 ## Paid Plan Credit Limits
 
-Paid plans include custom credit allocations based on your usage needs. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for plan details and pricing.
+Paid plans include progressively larger monthly credit allowances. See [shovels.ai/pricing](https://www.shovels.ai/pricing) for current allowances, or contact [sales@shovels.ai](mailto:sales@shovels.ai) for Enterprise volumes.
 
 <Info>
 For details on plan limits and pricing, see [shovels.ai/pricing](https://www.shovels.ai/pricing) or contact [sales@shovels.ai](mailto:sales@shovels.ai).

--- a/docs/knowledge-base/api/basics/request-counts.mdx
+++ b/docs/knowledge-base/api/basics/request-counts.mdx
@@ -29,7 +29,7 @@ This applies to all endpoints:
 | `GET /v2/contractors?id=abc,def,ghi` | 3 contractors | 3 |
 
 <Info>
-The credit system described above applies to **paid plans**. The free trial uses a simpler request-based system where each API call counts as 1 request, regardless of records returned.
+This applies to every plan, including Free. There is no separate request-based metering.
 </Info>
 
 ## Managing Your Credits

--- a/docs/knowledge-base/api/decisions/decisions-availability.mdx
+++ b/docs/knowledge-base/api/decisions/decisions-availability.mdx
@@ -13,7 +13,7 @@ Decisions are currently in **beta**. For the full story behind the dataset and w
 
 | Plan | Decisions Access |
 |------|------------------|
-| **API free trial** | Included—query the decisions endpoints with your trial key |
+| **Free plan** | Included—query the decisions endpoints with your API key |
 | **API paid plans** | Included at no additional charge |
 
 If you have an API key, you can query the [Search Decisions](/docs/knowledge-base/api/decisions/searching-decisions) and [Get Decisions By ID](/docs/knowledge-base/api/decisions/decisions-by-id) endpoints today.

--- a/docs/knowledge-base/cli/authentication.mdx
+++ b/docs/knowledge-base/cli/authentication.mdx
@@ -87,7 +87,7 @@ If you don't have an API key yet:
 2. Open the [**API key** tab](https://app.shovels.ai/account?tab=apikey)
 3. Copy your API key from the **API Key** field
 
-Free accounts include 250 requests to explore the platform.
+Free accounts include a monthly credit allowance to explore the platform—see [shovels.ai/pricing](https://www.shovels.ai/pricing).
 
 ## Related Articles
 

--- a/docs/knowledge-base/edl/sample-records.mdx
+++ b/docs/knowledge-base/edl/sample-records.mdx
@@ -23,7 +23,7 @@ Reach out to customer support with your request:
 
 ### 3. API Option
 
-If you're considering using the API, you can also explore the data yourself with a free trial:
+If you're considering using the API, you can also explore the data yourself on the Free plan:
 - [Create a free account](https://app.shovels.ai/login?mode=register)
 - Get 250 free API requests to test
 
@@ -50,4 +50,4 @@ The more specific your request, the more relevant the samples we can provide.
 
 - [EDL overview](/docs/knowledge-base/edl/overview)
 - [Manual reports](/docs/knowledge-base/edl/manual-reports)
-- [Free trial guide](/docs/knowledge-base/getting-started/free-trial-guide)
+- [Free plan guide](/docs/knowledge-base/getting-started/free-trial-guide)

--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -1,15 +1,15 @@
 ---
-title: "What's Included in the Shovels Free Trial?"
-description: "The Shovels free trial includes permit and contractor search, filters, and 250 API requests with full historical access. No credit card required."
+title: "What's Included in the Shovels Free Plan?"
+description: "The Shovels Free plan includes permit and contractor search, all filters, and 500 credits per month. No credit card required."
 ---
 
-**The Shovels free trial includes full permit and contractor search, all filters, and 250 API requests.** No credit card required. Paid plans unlock CSV downloads and higher API credit limits.
+**The Shovels Free plan includes full permit and contractor search, all filters, and 500 credits per month.** No credit card required. Paid plans unlock CSV downloads and larger credit allowances.
 
 <Info>
-**Free trial vs. paid plans:** The free trial is request-based—each API call counts as 1 request, regardless of how many records it returns. Paid plans use a credit system where each record returned counts against your credits.
+**One credit is one record.** Every plan is metered the same way—each record returned counts as one credit, on Free and paid plans alike.
 </Info>
 
-## Features Available in the Free Trial
+## Features Available on the Free Plan
 
 ### Permit & Contractor Search
 
@@ -17,8 +17,8 @@ Users can access the **permit** and **contractor** search functionality from the
 
 ### Data Availability
 
-- **Shovels Online**: The free trial includes access to the last 12 months of permit and contractor data. Paid plans unlock all historical data (on average, 25+ years).
-- **API**: The free trial includes access to the full historical dataset—no date restrictions.
+- **Shovels Online**: The Free plan includes access to the last 12 months of permit and contractor data. Paid plans unlock all historical data (on average, 25+ years).
+- **API**: The Free plan includes access to the full historical dataset—no date restrictions.
 
 ### Filters and Sorting
 
@@ -36,13 +36,13 @@ Shovels data is refreshed twice a month. See [data refresh frequency](/docs/know
 
 ## Getting Started
 
-1. [Create a free account](https://app.shovels.ai/login?mode=register) to begin your trial
+1. [Create a free account](https://app.shovels.ai/login?mode=register) to get started
 2. Use the search functionality to explore permits and contractors
 3. Apply filters to narrow down your results
 4. Explore contractor profiles and permit details
 
 <Info>
-The free trial provides a great way to evaluate Shovels' data quality and coverage before committing to a paid plan.
+The Free plan is a great way to evaluate Shovels' data quality and coverage before committing to a paid plan.
 </Info>
 
 ## Next Steps

--- a/docs/knowledge-base/getting-started/pricing-structure.mdx
+++ b/docs/knowledge-base/getting-started/pricing-structure.mdx
@@ -49,4 +49,4 @@ For questions about pricing or to discuss your specific needs:
 
 - [How do I cancel my subscription?](/docs/knowledge-base/shovels-online/cancel-subscription)
 - [Refund policy](/docs/knowledge-base/company/refund-policy)
-- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [What's included in the Free plan?](/docs/knowledge-base/getting-started/free-trial-guide)

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -180,7 +180,7 @@ A flexible zoning classification for master-planned projects that allows develop
 ## R
 
 ### API Credit Limit
-The maximum number of records you can retrieve via the API based on your paid plan. Each record returned counts against your credits. Paid plans have custom limits—contact sales for details. Note: the free trial uses a request-based system (250 requests) rather than credits. See [API credit limits](/docs/knowledge-base/api/basics/credit-limits) for full information.
+The number of records you can retrieve per month on your plan. Each record returned counts as one credit, on every plan including Free. See [shovels.ai/pricing](https://www.shovels.ai/pricing) for per-plan allowances and [API credit limits](/docs/knowledge-base/api/basics/credit-limits) for full information.
 
 ### API Rate Limit
 A technical limit on how quickly you can make API requests. Rate limits protect system stability and ensure fair access for all users. If you exceed the rate limit, you'll receive a 429 Too Many Requests response. See [API rate limits](/docs/knowledge-base/api/basics/rate-limits) for details.

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -18,7 +18,7 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 
 <CardGroup cols={2}>
   <Card title="Getting Started" icon="rocket" href="/docs/knowledge-base/getting-started/free-trial-guide">
-    New to Shovels? Learn about free trials, pricing, and what makes us different.
+    New to Shovels? Learn about the Free plan, pricing, and what makes us different.
   </Card>
   <Card title="Shovels CLI" icon="code" href="/docs/knowledge-base/cli/installation">
     Install and use the command-line tool for permits, contractors, and scripting.
@@ -45,7 +45,7 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 ### Getting Started
 - [What makes Shovels different?](/docs/knowledge-base/getting-started/key-differentiators)
 - [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
-- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [What's included in the Free plan?](/docs/knowledge-base/getting-started/free-trial-guide)
 - [What is Charlie?](/docs/knowledge-base/shovels-online/charlie)
 
 ### Using the CLI

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -11,10 +11,10 @@ Fast, concise answers to the most frequently asked questions about Shovels.
 ## Pricing & Plans
 
 ### How much does Shovels cost?
-Shovels Online and API pricing starts with a free tier. View current plans at [shovels.ai/pricing](https://www.shovels.ai/pricing). Enterprise Data License (EDL) pricing requires contacting [sales@shovels.ai](mailto:sales@shovels.ai).
+Shovels Online and API pricing starts with a Free plan. View current plans at [shovels.ai/pricing](https://www.shovels.ai/pricing). Enterprise Data License (EDL) pricing requires contacting [sales@shovels.ai](mailto:sales@shovels.ai).
 
-### Is there a free trial?
-Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.
+### Is there a free plan?
+Yes. The Free plan has no time limit and needs no credit card. In Shovels Online it covers the last 12 months of data; through the API it covers the full historical dataset. See [shovels.ai/pricing](https://www.shovels.ai/pricing) for its monthly credit allowance.
 
 ### How do I cancel my subscription?
 Log in at [app.shovels.ai/account](https://app.shovels.ai/account) → **Manage subscription** → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
@@ -34,7 +34,7 @@ Internal business use: research, prospecting, lead generation, and product integ
 ## API Basics
 
 ### What is my API limit?
-The free trial includes **250 requests** (each API call = 1 request, regardless of records returned). Paid plans use a credit system with custom credit limits where each record returned counts against your credits. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for details.
+Every plan is metered in credits, where one credit is one record returned. The Free plan includes **500 credits per month**; see [shovels.ai/pricing](https://www.shovels.ai/pricing) for paid plan allowances.
 
 ### How many records per API call?
 Search endpoints return up to 100 records per page (default: 10). Detail endpoints accept up to 50 IDs per call.
@@ -181,7 +181,7 @@ Depends on project complexity: 2-4 weeks for minor commercial renovations, 1-3 m
 Property location and coordinates, zoning changes (previous and new), involved parties (applicant, owner, developer, representative), project value and lot size, allowed uses, a "why it matters" summary, and a link to the source meeting record.
 
 ### Which plans include Decisions?
-All of them. Decisions are included in the API free trial and in every paid plan at no additional charge. Decisions are currently in beta.
+All of them. Decisions are included on every plan, Free and paid, at no additional charge. Decisions are currently in beta.
 
 ### How do I query Decisions in the API?
 Use the [Search Decisions](/docs/knowledge-base/api/decisions/searching-decisions) endpoint. It requires a date range (`decision_from`, `decision_to`) and a `geo_id`. To fetch specific records, use [Get Decisions By ID](/docs/knowledge-base/api/decisions/decisions-by-id) with up to 50 IDs.
@@ -206,7 +206,7 @@ No. The same contractor operating in multiple states has separate IDs per state.
 
 ## Shovels Online
 
-### What can I do with the free trial?
+### What can I do on the Free plan?
 Search permits and contractors, use filters, and explore the last 12 months of data. CSV downloads require a paid plan.
 
 ### What is Charlie?

--- a/docs/knowledge-base/shovels-online/cancel-subscription.mdx
+++ b/docs/knowledge-base/shovels-online/cancel-subscription.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How Do I Cancel My Shovels Subscription?"
-description: "Cancel your Shovels subscription anytime from the Manage subscription tab of your account, in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
+description: "Cancel your Shovels subscription anytime from the Manage subscription tab of your account, in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the Free plan."
 ---
 
 **You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai/account](https://app.shovels.ai/account), open the **Manage subscription** tab, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
@@ -16,8 +16,8 @@ description: "Cancel your Shovels subscription anytime from the Manage subscript
 
 - You retain full access until your billing period ends
 - You will not be charged again after cancellation
-- Your data and account remain accessible until the period ends, then revert to free tier
-- Your API key remains active on the free tier (**250 requests**)
+- Your data and account remain accessible until the period ends, then revert to the Free plan
+- Your API key remains active on the Free plan
 
 ## Cancelling an Enterprise Data License (EDL)
 
@@ -40,4 +40,4 @@ See our [Refund Policy](/docs/knowledge-base/company/refund-policy) for refund e
 
 - [Refund policy](/docs/knowledge-base/company/refund-policy)
 - [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
-- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [What's included in the Free plan?](/docs/knowledge-base/getting-started/free-trial-guide)

--- a/docs/knowledge-base/shovels-online/charlie.mdx
+++ b/docs/knowledge-base/shovels-online/charlie.mdx
@@ -43,6 +43,6 @@ Charlie is available in [Shovels Online](https://app.shovels.ai) once you sign i
 ## Related Articles
 
 - [How Shovels Online works](/docs/knowledge-base/shovels-online/how-it-works)
-- [What's included in the free trial?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [What's included in the Free plan?](/docs/knowledge-base/getting-started/free-trial-guide)
 - [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
 - [How do I access my API key?](/docs/knowledge-base/api/basics/api-key-access)

--- a/docs/knowledge-base/shovels-online/how-it-works.mdx
+++ b/docs/knowledge-base/shovels-online/how-it-works.mdx
@@ -69,7 +69,7 @@ Paid plans can export search results as CSV files, covering the full set of matc
 
 ## Related Articles
 
-- [Free trial guide](/docs/knowledge-base/getting-started/free-trial-guide)
+- [Free plan guide](/docs/knowledge-base/getting-started/free-trial-guide)
 - [Search functionality](/docs/knowledge-base/shovels-online/search-functionality)
 - [Filters and sorting](/docs/knowledge-base/shovels-online/filters-and-sorting)
 - [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -32,24 +32,24 @@ The use cases are endless, but the most common we see today are:
 To begin using the API, please contact our sales team at [sales@shovels.ai](mailto:sales@shovels.ai) or grab a [free API key](https://app.shovels.ai/login?mode=register).
 
 <Info>
-The free API key includes 250 requests. If you use them all and need more, please reach out to [sales@shovels.ai](mailto:sales@shovels.ai) or call us at [1-800-511-7457](tel:+18005117457).
+The Free plan includes a monthly credit allowance—see [shovels.ai/pricing](https://www.shovels.ai/pricing). If you need a larger one, reach out to [sales@shovels.ai](mailto:sales@shovels.ai) or call us at [1-800-511-7457](tel:+18005117457).
 </Info>
 
 ### API Key
 
 For any API request, you'll need to include your API key. This is available in your [Account → API key](https://app.shovels.ai/account?tab=apikey).
 
-### API Free Trial
+### API Access on the Free Plan
 
-We want you to be able to adequately test our API before making your decision. Completely separate from the Shovels Online web app trial, there is a free trial of the API key as well.
+We want you to be able to adequately test our API before making your decision. API access is included on every plan, including Free—there is no separate API trial to start.
 
-API Key free trials include **250 free requests** with no time limit or credit card required. Each API call counts as 1 request, regardless of how many records are returned—so a search returning 100 permits still counts as just 1 request.
+The Free plan has no time limit and needs no credit card. Its credits are shared with Shovels Online: each record an API call returns counts as one credit, so a search returning 100 permits uses 100 credits.
 
 <Info>
-**Free trial vs. paid plans:** The free trial is request-based (250 requests, each API call = 1 request). Paid plans use a credit system where each record returned counts against your credits. See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for details on the paid credit system.
+**One credit is one record.** Every plan is metered the same way, on Free and paid plans alike. See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for details on the credit system.
 </Info>
 
-If you use all your free trial requests and need more, please reach out to [Sales](mailto:sales@shovels.ai) for an extension.
+If you need a larger monthly credit allowance, please reach out to [Sales](mailto:sales@shovels.ai).
 
 ## Authentication
 

--- a/docs/shovels-cli-quickstart.mdx
+++ b/docs/shovels-cli-quickstart.mdx
@@ -36,7 +36,7 @@ shovels version
 
 ## Configure Your API Key
 
-You need a Shovels API key. If you don't have one, [create a free account](https://app.shovels.ai/login?mode=register) to get a key with 250 free requests.
+You need a Shovels API key. If you don't have one, [create a free account](https://app.shovels.ai/login?mode=register) to get a key on the Free plan.
 
 There are two ways to provide your API key:
 
@@ -216,7 +216,7 @@ You can set up the Shovels CLI inside [Claude Cowork](https://claude.ai/cowork) 
 
 **Download the Shovels CLI binary** — Go to [github.com/ShovelsAI/shovels-cli/releases/latest](https://github.com/ShovelsAI/shovels-cli/releases/latest) and download the `linux_arm64` release (the file ending in `.tar.gz`). Save it to your Cowork folder.
 
-You'll also need your Shovels API key handy. If you don't have one, [create a free account](https://app.shovels.ai/login?mode=register) to get a key with 250 free requests.
+You'll also need your Shovels API key handy. If you don't have one, [create a free account](https://app.shovels.ai/login?mode=register) to get a key on the Free plan.
 
 <Warning>
 Only the `linux_arm64` binary works in Cowork. The Cowork environment runs on Linux (arm64 architecture), so make sure you download that specific version from the releases page — not the macOS, Windows, or amd64 versions.

--- a/docs/shovels-online-quickstart-guide.mdx
+++ b/docs/shovels-online-quickstart-guide.mdx
@@ -36,9 +36,9 @@ We provide a 7 day Free Trial for all new users, which will allow you to explore
 
 We also understand that you may need additional time to test and vet the system. If your free trial expires, please reach out to [Sales](mailto:sales@shovels.ai) and we'll be happy to help. 
 
-#### Free Trial API Key
+#### Free Plan API Key
 
-All Free Trial accounts are also provided with an API Key, which has a separate, non-time based limit of **250 requests**. Each API call counts as 1 request, regardless of how many records are returned. Even if your Shovels Online free trial expires, you may continue to test the API with this key until you've used all your requests.
+Every account is also provided with an API Key. It draws on the same monthly credit balance as Shovels Online, so a record you retrieve through the API counts the same as a record you export from the web app. The Free plan does not expire.
 
 To find your API key, click on your email address in the top right corner. From the account profile page, click the "API Key" tab to view your key, as well as some helpful resources for getting started. 
 


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 2. Larger than the other PRs in this pass — the reasoning for keeping it whole is below.

The docs described the free tier as a **250-request trial** metered on a *separate system* from paid plans. Neither half is true: `FREE_TIER_CREDIT_LIMIT = 500` in the app's Stripe webhook handler, credits meter records on every plan including Free, and no time-based trial exists in the product at all (commit `58f8a54` dropped trial fields; `trialing` survives only as a Stripe subscription status).

**Changes**

Free-tier allowance — **500 credits** stated as a figure in the 4 places a reader needs it to decide whether to sign up:
- `getting-started/free-trial-guide.mdx` — frontmatter `description` and lede.
- `api/basics/credit-limits.mdx` — "## Free Plan" section (was "## Free Trial", *"provides **250 requests**"*).
- `quick-answers.mdx` — "What is my API limit?".

Named-and-linked everywhere else, extending PR #46's approach so there is one place to maintain: `glossary.mdx`, `cli/authentication.mdx`, `api/basics/api-key-access.mdx`, `shovels-online/charlie.mdx`, `shovels-online/cancel-subscription.mdx`, `edl/sample-records.mdx`, `index.mdx`, `decisions/decisions-availability.mdx`.

Two sites stated the retired model with no number attached, so the original `250` grep missed them:
- `api/basics/request-counts.mdx` — still claimed the credit system *"applies to **paid plans**"* with the free tier on "a simpler request-based system". This is the article PR #45 corrected, and the canonical credit reference the others link to.
- `api/basics/credit-limits.mdx` — lede opened *"API credit limits apply to paid plans"*.

Documentation-tab articles carried 6 more copies. Same rationale as PR #48: the credit model is interface-independent, and leaving the quickstarts contradicting the KB would defeat the change.
- `shovels-api-introduction.mdx` ×4 (incl. an "### API Free Trial" section describing a trial "completely separate from the Shovels Online web app trial").
- `shovels-cli-quickstart.mdx` ×2, `shovels-online-quickstart-guide.mdx` ×1.

**"Trial" → "Free plan" is part of this change, not cosmetic.** `shovels-online-quickstart-guide.mdx` said *"Even if your Shovels Online free trial expires…"* — the Free plan does not expire, so "trial" asserts a false expiry. The article's own name changes with it (title + 4 inbound link labels); the **slug stays `free-trial-guide`**, so no redirect is needed and no external link breaks.

**Deliberately left in place:** `shovels-online-quickstart-guide.mdx` lines 31–37 and 109 describe a **7-day** Free Trial with reduced date-filter options. Verified dead against the app, but correcting it means rewriting a walkthrough section (and line 109's filter claim), so it belongs with the Shovels Online walkthrough work rather than here. The file's API-key section *is* updated, so it is knowingly half-done — flagged on the issue.

Also untouched, for later PRs in this pass: Charlie is metered in **tokens**, not credits (`charlie.mdx` still says credits — `lib/constants/quota.ts` gives Free 250K/mo, paid 2M), the retired **Profile Settings** / **Account Settings** labels, and the paid-only export wording.

**Validation:** `mint broken-links` (4.2.3) — no new flags. Remaining are the known `/api-reference` false positives plus the one genuine pre-existing break in `foundations-building-blocks.mdx`. Residue greps for `250 requests`, `request-based`, `free trial`, and `free tier` are clean outside the deliberate exclusion above.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.