### PR TITLE
Make the pricing table choose an interface

### DIFF
--- a/docs/knowledge-base/getting-started/pricing-structure.mdx
+++ b/docs/knowledge-base/getting-started/pricing-structure.mdx
@@ -22,18 +22,21 @@ Shovels plans are credit-based: one credit is one record returned. See [How do A
 
 For Enterprise Data options, please contact [sales@shovels.ai](mailto:sales@shovels.ai) to discuss your custom needs.
 
-## Choosing the Right Product
+## Choosing an Interface
 
-| Product | Best For | Key Features |
-|---------|----------|--------------|
-| **Shovels Online** | Individual users, quick lookups | Web interface, CSV downloads, 12+ months history |
-| **Shovels API** | Product integrations, developers | Programmatic access, real-time queries, 10K+ calls/month |
-| **Enterprise (EDL)** | Data teams, bulk analysis | Full dataset, Snowflake/BigQuery delivery, all fields |
+Every interface below is included on every plan, and they all draw on the same monthly credit balance—so you can move between them without changing plans.
+
+| Interface | Best For | What It Is |
+|-----------|----------|------------|
+| **Shovels Online** | Quick lookups, no code | Web search, filters, map, and CSV export |
+| **Shovels API** | Product integrations | REST endpoints for programmatic queries |
+| **Shovels CLI** | Terminals and AI agents | Single binary, JSON output, no dependencies |
+| **Charlie** | Questions in plain English | The AI agent inside Shovels Online |
 
 <Info>
-**When to choose API vs EDL:**
+**When to choose the API vs an EDL:**
 - The **API** is great for looking up addresses and contractors, product integrations, and local lead lists
-- **EDL** is ideal when you need every contractor across multiple counties with all available fields
+- An **EDL** is ideal when you need every contractor across multiple counties with all available fields
 </Info>
 
 ## Contact Sales


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 3.

PR #46 moved `pricing-structure.mdx` to the name-tiers-and-link approach, but its "Choosing the Right Product" table kept hardcoded plan figures and was structured around the pre-refresh product split. Two of its three rows contradicted the credit model stated higher up the same page.

**Changes**
- `getting-started/pricing-structure.mdx`:
  - Heading → **Choosing an Interface** (was "Choosing the Right Product"); columns → Interface / Best For / What It Is.
  - Dropped `10K+ calls/month` — matches no plan, and meters *calls* when credits meter records.
  - Dropped `12+ months history` — history depth is a plan property (and Shovels Online only; the API is unrestricted), so it belongs with the Plans section, not in an interface table.
  - Added **Shovels CLI** and **Charlie**. The pricing page names four interfaces sharing one credit balance; the table listed two of them.
  - Dropped the **Enterprise (EDL)** row — it read as a peer of the interfaces while having its own section directly above.
  - Added one line above the table: every interface is included on every plan and they share the same monthly credit balance.

That leaves the article with zero hardcoded plan figures, which is what PR #46 set out to do.

**Note for merge order:** PR #49 also touches this file, one line at the bottom (a "free trial" → "Free plan" link label). Different hunk — the two merge cleanly in either order.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. Rendered locally and confirmed the removed figures are gone from the served page.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.