### PR TITLE
Correct the Shovels Online export limits

### DIFF
--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -28,7 +28,7 @@ Users can utilize various filters to refine their searches. Filters are availabl
 - Permit
 - Contractor
 
-Paying customers can download search results and sort them in Excel or Google Sheets.
+Exporting search results to CSV requires a paid plan. Paid plans can export the full set of matching records and sort them in Excel or Google Sheets.
 
 ### Data Refresh Rate
 

--- a/docs/knowledge-base/shovels-online/contractor-downloads.mdx
+++ b/docs/knowledge-base/shovels-online/contractor-downloads.mdx
@@ -79,7 +79,7 @@ This contractor intelligence enables you to:
 4. Select CSV format
 
 <Info>
-CSV downloads are available to paying customers. Trial accounts have limited download access.
+CSV export requires a paid plan; the export action is unavailable on the Free plan. Exports cover the full set of matching records with no per-export cap, and each exported record spends one credit.
 </Info>
 
 ## Related Articles

--- a/docs/knowledge-base/shovels-online/how-it-works.mdx
+++ b/docs/knowledge-base/shovels-online/how-it-works.mdx
@@ -60,7 +60,7 @@ Note that some permits may not have addresses—this is common with new construc
 
 ## Data Export
 
-Paying customers can download search results as CSV files. This feature is not available on trial accounts.
+Paid plans can export search results as CSV files, covering the full set of matching records. Export is unavailable on the Free plan. Each exported record spends one credit.
 
 ## Contact Information
 

--- a/docs/knowledge-base/shovels-online/permit-downloads.mdx
+++ b/docs/knowledge-base/shovels-online/permit-downloads.mdx
@@ -71,12 +71,12 @@ Duration metrics track:
 3. Click the download button
 4. Select CSV format
 
-<Warning>
-**Download limit:** For performance reasons, Shovels Online limits downloads to **1,000 records** per search. To export more records, break your query into smaller segments (e.g., filter by city instead of state) and run each separately.
-</Warning>
+<Info>
+**Exports cover the full set of matching records.** There is no per-export record cap, so you do not need to split a large search into smaller queries. Each exported record spends one credit—check your remaining balance before exporting a large result set.
+</Info>
 
 <Info>
-CSV downloads are available to paying customers. Trial accounts have limited download access. The API has no result limits for programmatic access.
+CSV export requires a paid plan; the export action is unavailable on the Free plan. Retrieving records through the API is metered the same way, one credit per record.
 </Info>
 
 ## Related Articles


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 4.

Two export claims were wrong, and the first was costing readers real work.

**The 1,000-record cap does not exist.** The article carried a `<Warning>` instructing readers to *"break your query into smaller segments (e.g., filter by city instead of state) and run each separately."* The live export dialog offers **"All matching results — Download all N matching contractors"**, and `app/api/{permits,contractors}/download` forward the search filters upstream with no record cap. Anyone who followed this advice segmented their queries for nothing.

The likely origin is `PRO_SEARCH_RESULT_LIMIT=1000` in the app's `.env.local.example` — a *browsing* cap that got written up as an export cap. Production browsing limits are 10 rows on Free and 100 on paid, which is a separate PR.

**"Trial accounts have limited download access" understated the restriction.** `lib/server/services/export-gating.ts` throws a hard 402 for any account without a paid subscription — Free has no export access at all, not a smaller allowance.

**Changes**
- `shovels-online/permit-downloads.mdx`: dropped the 1,000-record `<Warning>`; replaced with the constraint that does apply — an export spends **one credit per record**, so check the remaining balance before a large export. Export eligibility restated as paid-plan-only.
- `shovels-online/contractor-downloads.mdx`, `shovels-online/how-it-works.mdx`, `getting-started/free-trial-guide.mdx`: same eligibility correction, plus the per-record credit cost.

The credit cost is verified rather than inferred: the download paths are the only two call sites in shovels-online using `apiKeyUse: "userApiCreditsOnly"` (`lib/server/shovels/permits.ts:59`, `contractors.ts:65`), so they bill against the user's own key while browsing runs on the shared key.

**Deliberately left in place, two things:**
- `permit-downloads.mdx` "How to Download" still reads *"Click the download button / Select CSV format"*. The real flow is a **Download CSV** button opening a scope dialog. That is walkthrough accuracy rather than export limits, and belongs with the Shovels Online walkthrough PR — so this article briefly has corrected limits under slightly stale steps.
- *"The API has no result limits for programmatic access"* is preserved in meaning rather than sharpened. Whether upstream caps a `download=true` call is not verifiable from the app repo, so every new claim here says "the full set of matching records" — mirroring the product's own dialog wording — rather than asserting no limit.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. All four pages rendered locally and confirmed free of the removed strings.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.