### PR TITLE
Document the per-plan browsing limits

### DIFF
--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -215,6 +215,9 @@ Charlie is the AI chat assistant inside Shovels Online. Ask permit data question
 ### How does search work?
 Searches use AND logic—results match ALL selected criteria. You can search by geography, date range, permit type, keywords, and more.
 
+### How many results can I browse per search?
+Ten on the Free plan, 100 on paid plans. The match count is not limited—a search can report tens of thousands of matches while you browse the first 10 or 100. To work with more, export to CSV or query the API (both paid, one credit per record).
+
 ---
 
 ## Enterprise (EDL)

--- a/docs/knowledge-base/shovels-online/how-it-works.mdx
+++ b/docs/knowledge-base/shovels-online/how-it-works.mdx
@@ -22,6 +22,19 @@ You can search by description keywords. This is useful for finding:
 The search system does not account for typos or terminology variations. Contractors may use different abbreviations (like "SFR" instead of "single family residence"), so keep this in mind when searching.
 </Info>
 
+### How Many Results Can I Browse?
+
+A search always reports how many records match in total, but each plan limits how many of those you can page through:
+
+| Plan | Results you can browse per search |
+|------|-----------------------------------|
+| Free | 10 |
+| Paid plans | 100 |
+
+The match count itself is not limited, so a search can report tens of thousands of matches while you browse the first 10 or 100. Once you reach the limit, narrow your filters—by city instead of state, or a shorter date range—to bring the result set into view. Paid plans can also choose how many results appear per page.
+
+To work with more records than you can browse, export the results to CSV or query the API. Both require a paid plan and are metered in credits, at one credit per record. See [shovels.ai/pricing](https://www.shovels.ai/pricing) for plan details.
+
 ## Permit Statuses
 
 Permits in Shovels Online can have the following statuses:


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 5. Net-new content — the KB has never documented browsing limits.

PR #51 removed a fictional 1,000-record *export* cap whose likely origin was `PRO_SEARCH_RESULT_LIMIT` — a *browsing* cap. This documents the browsing cap that actually exists.

**The distinction that matters:** the cap is on results you can page through, not on the match count. `applySearchResultLimit` sets `accessible_total = min(limit, total_count)` while still reporting the true total, which is why the app shows *"Showing 1-10 of 10,000+"* next to *"You've reached your plan's browsing limit of 10 results."* Undocumented, that reads as a defect rather than a plan boundary.

**Changes**
- `shovels-online/how-it-works.mdx`: new **How Many Results Can I Browse?** section under Search Functionality — 10 on Free, 100 on paid, the match count is not capped, narrow filters to bring a result set into view, and export/API to reach records beyond the cap.
- `quick-answers.mdx`: new standalone entry, "How many results can I browse per search?".

Figures are stated rather than linked: they appear on the plan cards in both the app and the pricing page, so there is a canonical public surface. Pricing is linked alongside. Worth knowing they are set by `FREE_SEARCH_RESULT_LIMIT` / `PRO_SEARCH_RESULT_LIMIT` env vars, so they can move without a deploy — happy to go link-only instead.

**Merge-conflict check.** All five open PRs in this pass (#48, #49, #50, #51, this) were test-merged together: **all clean, no conflicts.** That test caught a real conflict in an earlier draft of this branch — it amended the answer directly beneath a heading that PR #49 renames, and adjacent lines conflict even when the changed lines differ. Restructured into a standalone Q&A entry placed clear of #49's hunks, and re-verified.

**Deliberately left out, two things:**
- `getting-started/free-trial-guide.mdx` — arguably the most important place for a Free reader to learn about the 10-result cap, but PRs #49, #50 and #51 already touch that file and a fourth adjacent hunk would manufacture conflicts across four in-flight branches. Better added once those merge.
- Page-size selection. Free is pinned to "15 per page" (badged Pro) while its browse cap is 10, so the control is inert on Free and spelling it out would confuse more than it explains. Reduced to "Paid plans can also choose how many results appear per page."

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. Both pages rendered locally.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.