### PR TITLE
Repoint account references at the Account page

### DIFF
--- a/docs/knowledge-base/api/basics/api-key-access.mdx
+++ b/docs/knowledge-base/api/basics/api-key-access.mdx
@@ -7,8 +7,8 @@ Your API key is required to authenticate all requests to the Shovels API.
 
 ## Accessing Your API Key
 
-1. [Log into your Shovels account](https://app.shovels.ai/profile-settings/)
-2. Navigate to the **Profile Settings** section
+1. [Log into your Shovels account](https://app.shovels.ai/account)
+2. Open the **API key** tab
 3. Your API key is displayed in the **API Key** field
 
 ## Using Your API Key
@@ -30,7 +30,7 @@ During the free trial, each API call counts as **1 request**, regardless of how 
 
 ## Tracking Your Usage
 
-You can view your API credit usage in the Profile Settings or by calling the `GET /v2/usage` endpoint. Credits operate on a 30-day rolling window.
+You can view your API credit usage on the Manage subscription tab of your account or by calling the `GET /v2/usage` endpoint. Credits operate on a 30-day rolling window.
 
 ## Need More Credits?
 

--- a/docs/knowledge-base/api/basics/automate-calls.mdx
+++ b/docs/knowledge-base/api/basics/automate-calls.mdx
@@ -55,7 +55,7 @@ Our [API documentation](/api-reference) provides code snippets in multiple langu
 5. **Respect the API** - Avoid frivolous or unnecessary requests
 
 <Tip>
-Check your API usage in Profile Settings to monitor your credit consumption.
+Check your API usage on the Manage subscription tab of your account to monitor your credit consumption.
 </Tip>
 
 ## Related Articles

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -43,7 +43,7 @@ Search endpoints return up to **100 records per page** (default: 50) by setting 
 
 ## Tracking Your Usage
 
-Monitor your API usage in the **Profile Settings** section of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
+Monitor your API usage on the **Manage subscription** tab of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
 
 ## Need Higher Credit Limits?
 

--- a/docs/knowledge-base/api/basics/request-counts.mdx
+++ b/docs/knowledge-base/api/basics/request-counts.mdx
@@ -67,9 +67,9 @@ Every API response includes credit tracking headers:
 | `X-Credits-Limit` | Your total credit limit (omitted if unlimited) |
 | `X-Credits-Remaining` | Credits remaining (omitted if unlimited) |
 
-### Via Profile Settings
+### Via Your Account
 
-You can also view credit usage in the **Profile Settings** section of your account at [app.shovels.ai](https://app.shovels.ai/profile-settings/).
+You can also view credit usage on the [Manage subscription tab](https://app.shovels.ai/account?tab=subscription) of your account.
 
 <Info>
 Credits reset monthly on your subscription or upgrade date.

--- a/docs/knowledge-base/cli/authentication.mdx
+++ b/docs/knowledge-base/cli/authentication.mdx
@@ -84,7 +84,7 @@ Some commands don't require authentication: `version`, `config show`, and `usage
 If you don't have an API key yet:
 
 1. [Create a free Shovels account](https://app.shovels.ai/create-account/)
-2. Go to [Profile Settings](https://app.shovels.ai/profile-settings/)
+2. Go to the [API key tab](https://app.shovels.ai/account?tab=apikey) of your account
 3. Copy your API key from the **API Key** field
 
 Free accounts include 250 requests to explore the platform.

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -18,7 +18,7 @@ A unique identifier assigned by Shovels to each distinct address in our database
 The governmental body responsible for issuing building permits in a specific geographic area. An AHJ is typically a city or county government that establishes building codes, conducts inspections, and maintains permit records. The United States has approximately 20,000 AHJs.
 
 ### API Key
-A unique authentication token required to access the Shovels API. Include it in the `X-API-Key` header of every request. Access your key at [app.shovels.ai/profile-settings](https://app.shovels.ai/profile-settings/).
+A unique authentication token required to access the Shovels API. Include it in the `X-API-Key` header of every request. Access your key on the [API key tab](https://app.shovels.ai/account?tab=apikey) of your account.
 
 ### Active (Permit Status)
 A permit status indicating the permit has been approved and issued. Work can proceed. Defined by the `issue_date` field.

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -17,7 +17,7 @@ Shovels Online and API pricing starts with a free tier. View current plans at [a
 Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.
 
 ### How do I cancel my subscription?
-Log in at [app.shovels.ai](https://app.shovels.ai) → Account Settings → Manage Subscription → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
+Log in at [app.shovels.ai](https://app.shovels.ai) → Account → Manage subscription → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
 
 ### What is Shovels' refund policy?
 Refunds are reviewed case-by-case for charges within the last 30 days. Email [support@shovels.ai](mailto:support@shovels.ai) with your account email and charge details. See [Refund Policy](/docs/knowledge-base/company/refund-policy).
@@ -43,7 +43,7 @@ Search endpoints return up to 100 records per page (default: 50). Detail endpoin
 Each record returned counts against your credits. A search returning 100 permits uses 100 credits; a single permit lookup uses 1 credit.
 
 ### Where do I find my API key?
-Log in at [app.shovels.ai/profile-settings](https://app.shovels.ai/profile-settings/) and find it in the API Key section.
+Log in and open the [API key tab](https://app.shovels.ai/account?tab=apikey) of your account.
 
 ### What does a 422 error mean?
 A required parameter is missing. Most commonly, you need to resolve an address to a geo_id first using the Address Search endpoint.

--- a/docs/knowledge-base/shovels-online/cancel-subscription.mdx
+++ b/docs/knowledge-base/shovels-online/cancel-subscription.mdx
@@ -1,14 +1,14 @@
 ---
 title: "How Do I Cancel My Shovels Subscription?"
-description: "Cancel your Shovels subscription anytime from Account Settings → Manage Subscription in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
+description: "Cancel your Shovels subscription anytime from Account → Manage subscription in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
 ---
 
-**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai](https://app.shovels.ai), open Account Settings, click Manage Subscription, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
+**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai](https://app.shovels.ai), open Account, click Manage subscription, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
 
 ## How to Cancel
 
 1. Log in at [app.shovels.ai](https://app.shovels.ai)
-2. Go to **Account Settings**
+2. Go to **Account**
 3. Click **Manage Subscription**
 4. You'll be taken to the Stripe billing portal
 5. Select **Cancel Subscription** and confirm

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -37,7 +37,7 @@ The free API key includes 250 requests. If you use them all and need more, pleas
 
 ### API Key
 
-For any API request, you'll need to include your API key. This is available in your [Profile Settings > API Key](https://app.shovels.ai/profile-settings).
+For any API request, you'll need to include your API key. This is available on the [API key tab](https://app.shovels.ai/account?tab=apikey) of your account.
 
 ### API Free Trial
 
@@ -188,7 +188,7 @@ Enter your API Key in the "Authentication" drop down (as shown below), and proce
 ![API Playground Authentication](/assets/screenshots/api-quickstart-guide-authentication.png)
 
 <Info>
-If you have forgotten your API key, or need one in the first place, this is available in your [Profile Settings > API Key](https://app.shovels.ai/profile-settings).
+If you have forgotten your API key, or need one in the first place, this is available on the [API key tab](https://app.shovels.ai/account?tab=apikey) of your account.
 </Info>
 
 ### Server

--- a/docs/shovels-api-troubleshooting.mdx
+++ b/docs/shovels-api-troubleshooting.mdx
@@ -9,7 +9,7 @@ When encountering an issue with the Shovels API, whether it's authentication, ex
 
 We'll describe these steps in detail here:
 
-1. **Check your API Key**: Ensure that your API key is accurate, and matches what you see in your [Shovels Account Settings](https://app.shovels.ai/profile-settings). 
+1. **Check your API Key**: Ensure that your API key is accurate, and matches what you see on the [API key tab](https://app.shovels.ai/account?tab=apikey) of your Shovels account. 
 2. **Check the Required Fields for the Endpoint**: The required fields may vary from endpoint to endpoint, so ensure that they're all included.
 3. **Confirm the Request Server**: Make sure that you're using the full `api.shovels.ai/v2` URL, and not just `/v2`. 
 4. **Double Check the Request Syntax**: This can vary widely based on the method you use to execute the request, but errors in query configuration can cause issues. Sometimes, the Request Examples in our [API Reference docs](/api-reference/) can help with this. 


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 6.

The app serves account management from `/account`, with tabs for Manage subscription, Account details, API key and Charlie AI. The **Profile Settings** and **Account Settings** pages the docs point at no longer exist — `app.shovels.ai/profile-settings` resolves to a login redirect rather than the key or usage the surrounding text promises.

All **17 sites** across 10 files, mapped by what each passage is actually about:

| Was | Now |
|---|---|
| `app.shovels.ai/profile-settings` (API key) | `app.shovels.ai/account?tab=apikey` |
| "Profile Settings" / "Account Settings" | **Account**, plus the named tab |
| "Account Settings → Manage Subscription" | "Account → Manage subscription" |
| credit usage location | Manage subscription tab (`?tab=subscription`) |

Deep-linked to the specific tab rather than bare `/account` wherever the text sends someone to find one thing. Those query parameters are the documented set (`subscription｜profile｜apikey｜chat`) and the page restores the tab from them, so the links land where the sentence says.

Files: `api/basics/{api-key-access,credit-limits,request-counts,automate-calls}.mdx`, `cli/authentication.mdx`, `shovels-online/cancel-subscription.mdx`, `glossary.mdx`, `quick-answers.mdx`, `shovels-api-introduction.mdx`, `shovels-api-troubleshooting.mdx`.

**Expect three merge conflicts, and leave them to me.** Three lines here are also edited by PRs #48 and #49, in each case at the *opposite end of the same sentence* — #48 replaces the "30-day rolling window" tail of `api-key-access.mdx:33` and `credit-limits.mdx:46`, #49 replaces the "free tier" tail of the `cancel-subscription.mdx` description, and this PR replaces the page name at the head of all three. Same line, so git conflicts regardless of merge order.

I tested it: merging #48 and #49 first produces exactly three conflicts, each resolved by keeping the new head *and* the new tail — no judgment needed. Whichever of these lands second, ping me or just let GitHub flag it; I will rebase and force-push rather than leaving it for the reviewer.

I originally staged this PR with those three sites excluded to keep all six PRs conflict-free, but that traded a two-minute rebase for a three-line follow-up PR that could only be written after #48/#49 merged — and a window where the docs named a page that does not exist. Not worth it; the sweep is complete instead.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. All nine touched pages rendered locally and return 200. `grep -rnE "Profile Settings|Account Settings|profile-settings" docs/` is clean.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.