### PR TITLE
Document the coverage signals in search

### DIFF
--- a/docs/knowledge-base/data/quality/few-results.mdx
+++ b/docs/knowledge-base/data/quality/few-results.mdx
@@ -3,7 +3,27 @@ title: "Why Am I Getting So Few Results?"
 description: "Common reasons Shovels searches return fewer results than expected: limited jurisdiction coverage, narrow filters, recent permits not yet indexed, or limited digitization."
 ---
 
-**If your search is returning fewer results than expected, the most common causes are limited jurisdiction coverage, filters that are too narrow, recent permits not yet indexed (1–2 month lag), or limited digitization in the local jurisdiction.** Most have easy workarounds.
+**If your search is returning fewer results than expected, the most common causes are limited jurisdiction coverage, filters that are too narrow, recent permits not yet indexed (1–2 month lag), or limited digitization in the local jurisdiction.** Most have easy workarounds, and Shovels Online flags the coverage-related ones before you run the search.
+
+## Check the Coverage Signals First
+
+When you pick a location and a complete date range, Shovels Online checks how well each filterable field is actually reported in that area for that period — and tells you before you run the search.
+
+| Signal | What it means | What to do |
+|--------|---------------|------------|
+| No warning | The field is reliably reported for this area and period | Filter normally |
+| A hint on the filter | Only some permits report this field; the hint gives the percentage | Still usable, but expect an incomplete result set |
+| The filter is disabled | Permits in this area don't report the field for the selected period | Applying it would exclude nearly every result, so it can't be applied |
+
+Disabled filters are left out of the search even when a value is still showing in the panel, so a greyed-out filter never quietly narrows your results.
+
+If the area and period contain no permits at all, Shovels Online blocks the search and asks you to change the location or dates instead of returning an empty list.
+
+When a banner appears above your results warning that matches may be incomplete, its **Review** action jumps straight to the filter responsible and highlights it.
+
+<Info>
+These signals are specific to the area *and* the date range you selected. The same filter can be reliable in one city and unavailable in another, or reliable for recent years and unavailable further back.
+</Info>
 
 ## 1. The Area Has Limited Coverage
 
@@ -30,10 +50,10 @@ The search system does not account for typos or terminology variations. Contract
 
 ## 3. Recent Permits May Not Be Indexed Yet
 
-Shovels data updates monthly, with a typical **1–2 month lag** between when a permit is issued and when it appears in Shovels. Permits filed in the last 4–8 weeks may not be visible yet.
+Shovels refreshes data twice a month, and there is a typical **1–2 month lag** between when a permit is issued and when it appears in Shovels. Permits filed in the last 4–8 weeks may not be visible yet.
 
 **What to do:**
-- If you're looking for very recent activity, check back next month
+- If you're looking for very recent activity, check back after the next refresh
 - For time-sensitive needs, contact [support@shovels.ai](mailto:support@shovels.ai) and we can check the pipeline
 
 ## 4. The Jurisdiction Uses Limited Digitization


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 8.

`few-results.mdx` was written for a product that gave no feedback. Shovels Online now checks how well each filterable field is actually reported for the selected area and period, hints when a field is thin, and disables filters the area doesn't report at all — so it diagnoses two of the article's four causes before the search runs. None of that was documented.

**Changes** — `data/quality/few-results.mdx`, +23/-3:
- New **Check the Coverage Signals First** section ahead of the numbered causes, covering the three real tiers from `lib/types/coverage.ts` (`reliable` / `partial` / `missing`) in user-facing terms: no warning, a hint with the reported percentage, or a disabled filter.
- Lede now notes that Shovels Online flags the coverage-related causes up front.
- An `<Info>` making the scoping explicit: coverage is per-field *and* per-date-range, so the same filter can be reliable in one city and unavailable in another, or reliable recently and unavailable further back.

Three behaviours documented specifically because they read as defects without explanation:
- **Disabled filters are dropped from the request** even when a stale value is still showing in the panel — a greyed-out filter never quietly narrows results.
- **An area and period containing no permits blocks the search**, rather than returning an empty list.
- **The results banner's Review action** reopens the filter panel, expands the affected section and highlights the hint.

**One cadence line fixed here rather than in #54.** Line 33 said *"Shovels data updates monthly, with a typical 1–2 month lag"*. It sits inside the section this PR reworks, so correcting it in the cadence PR would have guaranteed a conflict. Also changed "check back next month" → "after the next refresh". Noted on #54 as well.

**Deliberately left in place:** line 10's *"approximately 2,000 jurisdictions"*. The site now says **2,770+**, but that figure appears in 8 sites across 5 files (`quick-answers`, `glossary`, this article, `geographic/jurisdictions` ×2, `geographic/coverage-areas` ×3) and is a coverage-statistics change, not a coverage-signals one. Out of scope for today's batch.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. Rendered locally. Verified to merge clean against #54, the one PR with adjacent cadence edits.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.