### PR TITLE
Say when a permit status is current as of

### DIFF
--- a/docs/knowledge-base/data/permits/permit-lifecycle.mdx
+++ b/docs/knowledge-base/data/permits/permit-lifecycle.mdx
@@ -29,6 +29,8 @@ The permit lifecycle typically flows through several stages:
 
 For each status change, we update the corresponding date fields while maintaining the same unique identifier. This allows users to track a permit's complete history without piecing together fragments across multiple records.
 
+Status changes reach Shovels with the **twice-monthly** data refresh rather than in real time, so a permit carries its previous status until the refresh that captures the change. See [how often data is refreshed](/docs/knowledge-base/data/quality/refresh-frequency).
+
 ## Deduplication
 
 Our deduplication process ensures that even when jurisdictions report the same permit multiple times with different statuses, Shovels presents a single, up-to-date record with the most current information.
@@ -42,3 +44,4 @@ If a permit has a final status but no final date, it typically indicates an **ov
 - [Permit statuses explained](/docs/knowledge-base/data/permits/permit-statuses)
 - [Tracking multiple permits](/docs/knowledge-base/data/permits/permit-tracking)
 - [Understanding start and end dates](/docs/knowledge-base/data/permits/start-end-dates)
+- [How often is data refreshed?](/docs/knowledge-base/data/quality/refresh-frequency)

--- a/docs/knowledge-base/data/permits/permit-statuses.mdx
+++ b/docs/knowledge-base/data/permits/permit-statuses.mdx
@@ -44,6 +44,12 @@ If any part of the process stalls or gets restricted from progression.
 Disqualifying reasons and reporting timeframes vary by jurisdiction and local regulation.
 </Info>
 
+## How Current a Status Is
+
+Statuses are refreshed with the dataset **twice a month**, so a permit's status reflects what its jurisdiction reported as of the most recent refresh. A permit that was approved or finaled since then keeps its earlier status until the next refresh picks up the change.
+
+See [how often data is refreshed](/docs/knowledge-base/data/quality/refresh-frequency) for the cadence and the typical reporting lag between a jurisdiction issuing a permit and it appearing in Shovels.
+
 ## Special Cases
 
 ### "Unknown" and "None" Statuses
@@ -72,4 +78,5 @@ This can vary by city and county—some jurisdictions process more permit types 
 
 - [Shovels 101: Permit Statuses](https://www.shovels.ai/blog/shovels-101-permit-statuses/) - Blog post with detailed explanations
 - [Permit lifecycle](/docs/knowledge-base/data/permits/permit-lifecycle)
+- [How often is data refreshed?](/docs/knowledge-base/data/quality/refresh-frequency)
 - [Checking project completion](/docs/knowledge-base/data/permits/project-completion)


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 9. Closes the "`permit-statuses` + `permit-lifecycle` — updated 2×/month" item under **Data & datasets**.

**This was a miss, not a deferral.** PR #54 was reported as completing the cadence work, and it didn't cover these two articles. Everything in this pass so far has been driven by grepping for *wrong* text, which structurally cannot find content that is simply **absent** — and neither of these articles mentioned refresh cadence at all.

Framed as staleness rather than a bare cadence statement, because that is the question a reader actually has: both articles explain how a permit moves between statuses, but neither said *when* Shovels learns about a transition. Someone looking at `active` had no way to judge whether it was current.

**Changes** — +10/-0:
- `data/permits/permit-statuses.mdx`: new **How Current a Status Is** section — a status reflects what its jurisdiction reported as of the most recent refresh, and a permit approved or finaled since then keeps its earlier status until the next refresh picks up the change.
- `data/permits/permit-lifecycle.mdx`: **Status Updates** now notes that status changes arrive with the twice-monthly refresh rather than in real time.
- Both cross-link `data/quality/refresh-frequency`, which also serves the ticket's cross-linking goal — the cadence and the reporting lag together determine how stale a status can be.

**Out of scope:** the Decisions context the ticket pairs with this item. Still blocked — no Decisions surface exists in the app.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. Both pages rendered locally. Verified to merge clean against all eight other open PRs (#48–#55).

Linear: MAR-267. Reviewer: @rbucks — merge when ready.