### PR TITLE
Point address lookups at the working search

### DIFF
--- a/docs/knowledge-base/api/address-resolution/resolving-addresses.mdx
+++ b/docs/knowledge-base/api/address-resolution/resolving-addresses.mdx
@@ -53,7 +53,7 @@ If the address doesn't have any permits in our database, the API returns a 200 O
 
 ## Alternative: Shovels Online
 
-For quick lookups without code, use the **Location Search** feature in [Shovels Online](https://app.shovels.ai) to search by address directly.
+For quick lookups without code, search by address directly in [Shovels Online](https://app.shovels.ai): on the Permits tab, choose **Address** under the location filter and start typing. Address search is available on permit searches only.
 
 ## Related Articles
 

--- a/docs/knowledge-base/api/permits/permit-search.mdx
+++ b/docs/knowledge-base/api/permits/permit-search.mdx
@@ -44,7 +44,7 @@ The permit search endpoint supports additional filters:
 
 ## Alternative: Shovels Online
 
-For quick lookups without code, use the **Location Search** feature in [Shovels Online](https://app.shovels.ai) to search by address directly.
+For quick lookups without code, search by address directly in [Shovels Online](https://app.shovels.ai): on the Permits tab, choose **Address** under the location filter and start typing. Address search is available on permit searches only.
 
 ## Best Practices
 


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 10. From the 🟢 **Verify / cross-link** list — `api/permits/permit-search` and `api/address-resolution/resolving-addresses`.

Both articles told readers *"use the **Location Search** feature in [Shovels Online] to search by address directly."* The route carrying that name is a **placeholder**: per shovels-online's `docs/app-features/supporting-routes.md`, `/search` renders only a location-pin icon, a "Location Search" heading and **"Coming soon"**, with no controls, no API calls and no navigation entry. Anyone following the instruction hit a dead end.

Address search does exist — in the location filter on the main search page (`/`), and only for permit searches (`search.md`: *"Address is removed from the scope controls while the Contractors tab is active"*). Both articles now say that.

**Changes** — +2/-2:
- `api/permits/permit-search.mdx`
- `api/address-resolution/resolving-addresses.mdx`

---

**Verify-pass results for the rest of the 🟢 list**, so the ticket's checklist can be settled rather than left ambiguous:

| Target | Outcome |
|---|---|
| `cli/installation` | ✅ No change — `https://shovels.ai/install.sh` resolves 200 |
| `cli/commands-overview` | ✅ No change — its "monthly" matches are the `metrics monthly` subcommand, not refresh cadence |
| `cli/output-and-pagination` | ✅ No change |
| `cli/scripting-and-agents` | ✅ No change |
| `api/basics/api-key-access` | Covered by #48, #49, #53 |
| `api/permits/permit-search` | ⚠️ Fixed here |
| `api/errors/422-error` | ✅ No change — error semantics still accurate |
| `data/quality/few-results` | Covered by #55 |
| `cli/authentication` | Covered by #49, #53 |
| `quick-answers`, `glossary` | Covered by #49, #52, #53, #54 |
| `data/geographic/jurisdictions` | Deferred — only issue is the "approximately 2,000 jurisdictions" figure (site now says 2,770+), which spans 8 sites in 5 files |
| `edl/monthly-deliveries`, `edl/record-tracking` | Deferred — needs the twice-monthly reframe, a slug decision and a `docs.json` redirect |
| `company/data-usage-terms`, `company/contact-information` | Blocked — see the issue; three questions outstanding, one of them a Terms-vs-marketing contradiction on resale rights |
| `api/properties/property-search` | Blocked — Properties dataset not live |

Five targets verified as needing no change. The CLI set held up well, which tracks with MAR-257 having refreshed it for v0.8.0 recently.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break. Both pages rendered locally. Merges clean against all nine other open PRs.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.