### PR TITLE
Describe Charlie as an agent, not a credit cost

### DIFF
--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -48,6 +48,6 @@ The free trial provides a great way to evaluate Shovels' data quality and covera
 ## Next Steps
 
 - [Learn how Shovels Online works](/docs/knowledge-base/shovels-online/how-it-works)
-- [Try Charlie](/docs/knowledge-base/shovels-online/charlie) — the AI chat assistant in Shovels Online
+- [Try Charlie](/docs/knowledge-base/shovels-online/charlie) — the AI agent in Shovels Online
 - [Understand our pricing structure](/docs/knowledge-base/getting-started/pricing-structure)
 - Contact [sales@shovels.ai](mailto:sales@shovels.ai) for API access or enterprise products

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -32,7 +32,7 @@ A zoning change applied to a larger geographic area, often initiated by municipa
 The final approval issued by a jurisdiction certifying that a completed building complies with applicable codes and is safe to occupy. It marks the end of the development lifecycle that begins with a zoning decision and continues through permitting and construction.
 
 ### Charlie
-The AI chat assistant inside [Shovels Online](https://app.shovels.ai). Charlie answers natural-language questions about permit and contractor data using the full Shovels dataset, and consumes your Shovels API credits.
+The AI agent inside [Shovels Online](https://app.shovels.ai), opened with the **Agent** button. Charlie answers natural-language questions about permit and contractor data using the full Shovels dataset.
 
 ### Conditional Use Permit
 Another term for a Special Use Permit—permission to conduct a specific activity that isn't automatically allowed in a zone but may be approved with conditions. Terminology varies by jurisdiction.

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -210,7 +210,7 @@ No. The same contractor operating in multiple states has separate IDs per state.
 Search permits and contractors, use filters, and explore the last 12 months of data. CSV downloads require a paid plan.
 
 ### What is Charlie?
-Charlie is the AI chat assistant inside Shovels Online. Ask permit data questions in plain English instead of building a search with filters. Uses your API credits. See [What is Charlie?](/docs/knowledge-base/shovels-online/charlie).
+Charlie is the AI agent inside Shovels Online, opened with the **Agent** button. Ask permit data questions in plain English instead of building a search with filters. Included on every plan, with usage limits that scale with your plan. See [What is Charlie?](/docs/knowledge-base/shovels-online/charlie).
 
 ### How does search work?
 Searches use AND logic—results match ALL selected criteria. You can search by geography, date range, permit type, keywords, and more.

--- a/docs/knowledge-base/shovels-online/charlie.mdx
+++ b/docs/knowledge-base/shovels-online/charlie.mdx
@@ -4,7 +4,7 @@ description: "Charlie is the AI chat assistant inside Shovels Online. Ask permit
 sidebarTitle: "Charlie"
 ---
 
-**Charlie is the AI chat assistant inside [Shovels Online](https://app.shovels.ai).** Ask questions about permit data in plain English and get answers back in the app — no filters, no downloads, no code required. Charlie queries the full Shovels dataset and uses your Shovels API credits.
+**Charlie is the AI agent inside [Shovels Online](https://app.shovels.ai), where the button is labelled Agent.** Ask questions about permit data in plain English and get answers back in the app — no filters, no downloads, no code required. Charlie queries the full Shovels dataset.
 
 Charlie is part of Shovels Online rather than a separate tool, so any account with an active plan can start asking. There is no separate signup.
 
@@ -32,15 +32,13 @@ Charlie and the filter-based search answer different kinds of questions. Ask Cha
 For bulk exports or recurring data pulls, the [search and download tools](/docs/knowledge-base/shovels-online/how-it-works) in Shovels Online or the [API](/docs/knowledge-base/api/basics/api-key-access) will serve you better.
 </Info>
 
-## Credits & Access
+## Access and Limits
 
-Charlie uses your Shovels API credits and is available to any user with an active API plan. Free trial users receive **250 requests** to get started.
-
-See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for details on how requests are counted.
+Charlie is included on every plan, with usage limits that scale with your plan. If you reach a limit, Charlie will let you know.
 
 ## Getting Started
 
-Charlie is available in [Shovels Online](https://app.shovels.ai) once you sign in with your Shovels account.
+Charlie is available in [Shovels Online](https://app.shovels.ai) once you sign in with your Shovels account. Look for the **Agent** button above your search results.
 
 ## Related Articles
 


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267), credit pass PR 11. Closes the Charlie half of **Credit model behavior** and the `glossary` "Charlie / Agent" entry from the 🟢 verify list.

**Charlie does not draw on credits.** Verified in shovels-online: its only data tool is `sql_execution` against a Snowflake MCP server authenticated with a service credential, and `app/api/chat/route.ts` contains no Shovels API key or credit reference at all. Reading data on a company credential is free — credits are spent when records leave on *your* key, via the API or a Shovels Online export. Charlie sits with search, not with export.

**No token language either.** Per @rbucks, the token allowance is being retired as too complex and the token bar is coming out of the account page, replaced by usage limits that scale with the plan — a user who hits one is told to wait or upgrade, with the figure configurable and not exposed. Since that replacement is not live yet, the limit is described in general terms rather than naming a unit, a figure or a reset window:

> Charlie is included on every plan, with usage limits that scale with your plan. If you reach a limit, Charlie will let you know.

The `## Credits & Access` heading had to change with it — it named the thing being removed — so it is now `## Access and Limits`.

**Naming.** Charlie stays the name throughout: title, sidebar, headings and body are unchanged. "Agent" is introduced only where it earns its place, because readers arrive from two directions — from the app having seen only a button labelled **Agent**, or from marketing having seen only the name Charlie:
- `charlie.mdx` lede — "Charlie is the AI **agent** inside Shovels Online, where the button is labelled Agent"
- `charlie.mdx` Getting Started — "Look for the **Agent** button above your search results"
- `glossary.mdx` and `quick-answers.mdx` — "the AI agent… opened with the **Agent** button"
- `free-trial-guide.mdx` — "AI chat assistant" → "AI agent", the last remaining "chat assistant" phrasing

**Changes** — +7/-9 across 4 files: `shovels-online/charlie.mdx`, `glossary.mdx`, `quick-answers.mdx`, `getting-started/free-trial-guide.mdx`.

**Left deliberately:** `charlie.mdx:9` still reads "any account with an active plan can start asking". The Access section immediately below says "included on every plan", so Free is covered.

**Expect one conflict, and leave it to me.** This conflicts with **#49** on `charlie.mdx`. Unlike #53's conflicts, resolution here is **take-mine, not a union** — #49 rewrote those same lines to say Charlie *does* use credits, which this supersedes entirely. Merge after #49 and I will rebase and force-push. Clean against the other nine open PRs.

**Validation:** `mint broken-links` (4.2.3) — no new flags; remaining are the known `/api-reference` false positives plus the pre-existing `foundations-building-blocks.mdx` break.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.