### PR TITLE
Route docs CTAs by what the copy promises

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,7 @@
     "primary": {
       "type": "button",
       "label": "Free Trial",
-      "href": "https://app.shovels.ai"
+      "href": "https://app.shovels.ai/login?mode=register"
     }
   },
   "footer": {

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -20,7 +20,7 @@ If you need more requests during your trial, contact [sales@shovels.ai](mailto:s
 Paid plans include custom credit allocations based on your usage needs. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for plan details and pricing.
 
 <Info>
-For details on plan limits and pricing, [create an account](https://app.shovels.ai) to see current options or contact [sales@shovels.ai](mailto:sales@shovels.ai).
+For details on plan limits and pricing, [create an account](https://app.shovels.ai/login?mode=register) to see current options or contact [sales@shovels.ai](mailto:sales@shovels.ai).
 </Info>
 
 ## If You Hit Your Credit Limit

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -20,7 +20,7 @@ If you need more requests during your trial, contact [sales@shovels.ai](mailto:s
 Paid plans include custom credit allocations based on your usage needs. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for plan details and pricing.
 
 <Info>
-For details on plan limits and pricing, [create an account](https://app.shovels.ai/login?mode=register) to see current options or contact [sales@shovels.ai](mailto:sales@shovels.ai).
+For details on plan limits and pricing, see [shovels.ai/pricing](https://www.shovels.ai/pricing) or contact [sales@shovels.ai](mailto:sales@shovels.ai).
 </Info>
 
 ## If You Hit Your Credit Limit

--- a/docs/knowledge-base/cli/authentication.mdx
+++ b/docs/knowledge-base/cli/authentication.mdx
@@ -83,7 +83,7 @@ Some commands don't require authentication: `version`, `config show`, and `usage
 
 If you don't have an API key yet:
 
-1. [Create a free Shovels account](https://app.shovels.ai/create-account/)
+1. [Create a free Shovels account](https://app.shovels.ai/login?mode=register)
 2. Go to [Profile Settings](https://app.shovels.ai/profile-settings/)
 3. Copy your API key from the **API Key** field
 

--- a/docs/knowledge-base/edl/sample-records.mdx
+++ b/docs/knowledge-base/edl/sample-records.mdx
@@ -24,7 +24,7 @@ Reach out to customer support with your request:
 ### 3. API Option
 
 If you're considering using the API, you can also explore the data yourself with a free trial:
-- [Create a free account](https://app.shovels.ai)
+- [Create a free account](https://app.shovels.ai/login?mode=register)
 - Get 250 free API requests to test
 
 ## Example Requests

--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -36,7 +36,7 @@ Shovels data is updated monthly. See [data refresh frequency](/docs/knowledge-ba
 
 ## Getting Started
 
-1. [Create a free account](https://app.shovels.ai) to begin your trial
+1. [Create a free account](https://app.shovels.ai/login?mode=register) to begin your trial
 2. Use the search functionality to explore permits and contractors
 3. Apply filters to narrow down your results
 4. Explore contractor profiles and permit details

--- a/docs/knowledge-base/getting-started/pricing-structure.mdx
+++ b/docs/knowledge-base/getting-started/pricing-structure.mdx
@@ -12,7 +12,7 @@ description: "Shovels Online and the API share credit-based plans—Free, Basic,
 - **Pro** — small teams that need more credits and seats.
 - **Enterprise** — custom credits, seats, and support for larger organizations.
 
-For the current price, monthly credits, and seats on each plan, see [shovels.ai/pricing](https://www.shovels.ai/pricing), then [create an account or sign in](https://app.shovels.ai/) to subscribe.
+For the current price, monthly credits, and seats on each plan, see [shovels.ai/pricing](https://www.shovels.ai/pricing), then [create an account](https://app.shovels.ai/login?mode=register) or [sign in](https://app.shovels.ai/login) to subscribe.
 
 ## How Credits Work
 

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -11,7 +11,7 @@ Fast, concise answers to the most frequently asked questions about Shovels.
 ## Pricing & Plans
 
 ### How much does Shovels cost?
-Shovels Online and API pricing starts with a free tier. View current plans at [app.shovels.ai](https://app.shovels.ai). Enterprise Data License (EDL) pricing requires contacting [sales@shovels.ai](mailto:sales@shovels.ai).
+Shovels Online and API pricing starts with a free tier. View current plans at [shovels.ai/pricing](https://www.shovels.ai/pricing). Enterprise Data License (EDL) pricing requires contacting [sales@shovels.ai](mailto:sales@shovels.ai).
 
 ### Is there a free trial?
 Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -17,7 +17,7 @@ Shovels Online and API pricing starts with a free tier. View current plans at [a
 Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.
 
 ### How do I cancel my subscription?
-Log in at [app.shovels.ai](https://app.shovels.ai) → Account Settings → Manage Subscription → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
+Log in at [app.shovels.ai](https://app.shovels.ai/login) → Account Settings → Manage Subscription → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
 
 ### What is Shovels' refund policy?
 Refunds are reviewed case-by-case for charges within the last 30 days. Email [support@shovels.ai](mailto:support@shovels.ai) with your account email and charge details. See [Refund Policy](/docs/knowledge-base/company/refund-policy).

--- a/docs/knowledge-base/shovels-online/cancel-subscription.mdx
+++ b/docs/knowledge-base/shovels-online/cancel-subscription.mdx
@@ -3,11 +3,11 @@ title: "How Do I Cancel My Shovels Subscription?"
 description: "Cancel your Shovels subscription anytime from Account Settings → Manage Subscription in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
 ---
 
-**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai](https://app.shovels.ai), open Account Settings, click Manage Subscription, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
+**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai](https://app.shovels.ai/login), open Account Settings, click Manage Subscription, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
 
 ## How to Cancel
 
-1. Log in at [app.shovels.ai](https://app.shovels.ai)
+1. Log in at [app.shovels.ai](https://app.shovels.ai/login)
 2. Go to **Account Settings**
 3. Click **Manage Subscription**
 4. You'll be taken to the Stripe billing portal

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -29,7 +29,7 @@ The use cases are endless, but the most common we see today are:
 
 ## Getting Started
 
-To begin using the API, please contact our sales team at [sales@shovels.ai](mailto:sales@shovels.ai) or grab a [free API key](https://app.shovels.ai/create-account/).
+To begin using the API, please contact our sales team at [sales@shovels.ai](mailto:sales@shovels.ai) or grab a [free API key](https://app.shovels.ai/login?mode=register).
 
 <Info>
 The free API key includes 250 requests. If you use them all and need more, please reach out to [sales@shovels.ai](mailto:sales@shovels.ai) or call us at [1-800-511-7457](tel:+18005117457).

--- a/docs/shovels-cli-quickstart.mdx
+++ b/docs/shovels-cli-quickstart.mdx
@@ -36,7 +36,7 @@ shovels version
 
 ## Configure Your API Key
 
-You need a Shovels API key. If you don't have one, [create a free account](https://app.shovels.ai/create-account/) to get a key with 250 free requests.
+You need a Shovels API key. If you don't have one, [create a free account](https://app.shovels.ai/login?mode=register) to get a key with 250 free requests.
 
 There are two ways to provide your API key:
 
@@ -216,7 +216,7 @@ You can set up the Shovels CLI inside [Claude Cowork](https://claude.ai/cowork) 
 
 **Download the Shovels CLI binary** — Go to [github.com/ShovelsAI/shovels-cli/releases/latest](https://github.com/ShovelsAI/shovels-cli/releases/latest) and download the `linux_arm64` release (the file ending in `.tar.gz`). Save it to your Cowork folder.
 
-You'll also need your Shovels API key handy. If you don't have one, [create a free account](https://app.shovels.ai/create-account/) to get a key with 250 free requests.
+You'll also need your Shovels API key handy. If you don't have one, [create a free account](https://app.shovels.ai/login?mode=register) to get a key with 250 free requests.
 
 <Warning>
 Only the `linux_arm64` binary works in Cowork. The Cowork environment runs on Linux (arm64 architecture), so make sure you download that specific version from the releases page — not the macOS, Windows, or amd64 versions.

--- a/docs/shovels-online-quickstart-guide.mdx
+++ b/docs/shovels-online-quickstart-guide.mdx
@@ -20,9 +20,9 @@ Our coverage and data is not perfect, and we're reliant on individual permit jur
 
 ## Creating an Account
 
-If you haven't already, go to the [Create Account](https://app.shovels.ai/create-account/) page and enter in your details. 
+If you haven't already, go to the [Create Account](https://app.shovels.ai/login?mode=register) page and enter in your details. 
 
-If you already have an account, then just log in at [app.shovels.ai](https://app.shovels.ai). 
+If you already have an account, then just log in at [app.shovels.ai](https://app.shovels.ai/login). 
 
 For security purposes, we'll send a verification email with a magic link to get you started. 
 

--- a/docs/tutorial-online-contractor-search.mdx
+++ b/docs/tutorial-online-contractor-search.mdx
@@ -17,7 +17,7 @@ Let's get into it.
 
 <Steps>
      <Step title="Log in to Shovels Online" titleSize="h3" stepNumber={0}>
-          Log in with your username and password at [app.shovels.ai](https://app.shovels.ai).
+          Log in with your username and password at [app.shovels.ai](https://app.shovels.ai/login).
      </Step>
      
      <Step title="Select Geography" titleSize="h3" stepNumber={1}>


### PR DESCRIPTION
Applies the CTA routing rule from MAR-326 across the docs, and clears the dead `/create-account/` path. 18 links changed across 12 files, resolving to three destinations.

## The rule

| Copy promises | Destination |
|---|---|
| Self-serve action — "create a free account", "free API key", "Free Trial" | `app.shovels.ai/login?mode=register` |
| An existing relationship — "log in at…", "sign in" | `app.shovels.ai/login` |
| What things cost — "view current plans", "the current price" | `www.shovels.ai/pricing` |
| The product itself — "Shovels Online", "the web application" | `app.shovels.ai` (unchanged) |

## `/create-account/` was never a real route

Six links pointed at `app.shovels.ai/create-account/` — including the API introduction's "grab a free API key" and both CLI quickstart entry points. It has never served the account-creation form, so a reader told to create an account never got one. Zero occurrences remain.

For most of the time those links were live the path did not even 404: a blanket rule redirected unknown paths to `/login`, so the reader hit a sign-in wall and every link checker followed the redirect to a 200 and passed. **That has since been fixed** — as of 23 Aug the app returns real 404s for unknown paths, so this class of breakage is detectable going forward. Either way, these six links were dead and are now repointed.

## Why the query param and not `/register`

The `/register` alias rewrites to `/login?mode=register` and discards the entire query string, taking `gclid` and UTMs with it. Docs links that end up in an email or ad would lose attribution with no visible symptom. `/login?mode=register` is the canonical form. Filed as FRO-375; still open at time of writing.

## Changed

**To registration (9)** — `docs.json` nav button, `shovels-online-quickstart-guide`, `shovels-cli-quickstart` ×2, `shovels-api-introduction`, `cli/authentication`, `edl/sample-records`, `getting-started/free-trial-guide`, `getting-started/pricing-structure`

**To sign-in (6)** — `shovels-online/cancel-subscription` ×2, `quick-answers`, `tutorial-online-contractor-search`, `shovels-online-quickstart-guide`, `getting-started/pricing-structure`

**To the pricing page (3)** — `quick-answers`, `getting-started/pricing-structure`, `api/basics/credit-limits`

`pricing-structure` had "create an account or sign in" as a single link to a single destination; it is now two links.

## Left unchanged on purpose

Links naming the product rather than an action keep the bare app origin — "Shovels Online" ×5, the intro card, the glossary entry — so a signed-in reader lands in the app. Same call MAR-326 made for 33 blog links. `www.shovels.ai/contact` ×4 was already correct.

~~`/profile-settings/` deep links ×6 — already correct.~~ **Struck: this was wrong.** `app.shovels.ai/profile-settings` does not resolve; the account page moved to `app.shovels.ai/account`. See the correction comment below. No commit in this PR touches those links, so the diff here is unaffected — fixed separately in #60.

## Review notes

1. **Destinations confirmed by hand on 23 Aug.** All three were clicked through in a browser: `?mode=register` renders "Create your Shovels Platform account", `/login` renders "Sign in to Shovels Platform", and the pricing page loads without an account. An earlier revision of this description flagged these as unverified — that no longer applies.

2. **`a3696ee` is a judgment call.** `credit-limits.mdx` told readers to create an account "to see current options" — copy written while prices were gated. It now points at the public pricing page, which removes a signup CTA from that page. Isolated in its own commit so it can be dropped without touching the rest.

Closes MAR-329.