### PR TITLE
Repoint account links at the new account page

### DIFF
--- a/docs/knowledge-base/api/basics/api-key-access.mdx
+++ b/docs/knowledge-base/api/basics/api-key-access.mdx
@@ -7,8 +7,8 @@ Your API key is required to authenticate all requests to the Shovels API.
 
 ## Accessing Your API Key
 
-1. [Log into your Shovels account](https://app.shovels.ai/profile-settings/)
-2. Navigate to the **Profile Settings** section
+1. [Log in to your Shovels account](https://app.shovels.ai/account?tab=apikey)
+2. Open the **API key** tab
 3. Your API key is displayed in the **API Key** field
 
 ## Using Your API Key
@@ -30,7 +30,7 @@ During the free trial, each API call counts as **1 request**, regardless of how 
 
 ## Tracking Your Usage
 
-You can view your API credit usage in the Profile Settings or by calling the `GET /v2/usage` endpoint. Credits operate on a 30-day rolling window.
+You can view your API credit usage on the **Manage subscription** tab of your account or by calling the `GET /v2/usage` endpoint. Credits operate on a 30-day rolling window.
 
 ## Need More Credits?
 

--- a/docs/knowledge-base/api/basics/automate-calls.mdx
+++ b/docs/knowledge-base/api/basics/automate-calls.mdx
@@ -55,7 +55,7 @@ Our [API documentation](/api-reference) provides code snippets in multiple langu
 5. **Respect the API** - Avoid frivolous or unnecessary requests
 
 <Tip>
-Check your API usage in Profile Settings to monitor your credit consumption.
+Check your API usage on the **Manage subscription** tab of your account to monitor your credit consumption.
 </Tip>
 
 ## Related Articles

--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -43,7 +43,7 @@ Search endpoints return up to **100 records per page** (default: 50) by setting 
 
 ## Tracking Your Usage
 
-Monitor your API usage in the **Profile Settings** section of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
+Monitor your API usage on the **Manage subscription** tab of your account or via the `GET /v2/usage` endpoint. Credits operate on a **30-day rolling window**—your usage resets based on when credits were consumed, not on a fixed calendar date.
 
 ## Need Higher Credit Limits?
 

--- a/docs/knowledge-base/api/basics/request-counts.mdx
+++ b/docs/knowledge-base/api/basics/request-counts.mdx
@@ -67,9 +67,9 @@ Every API response includes credit tracking headers:
 | `X-Credits-Limit` | Your total credit limit (omitted if unlimited) |
 | `X-Credits-Remaining` | Credits remaining (omitted if unlimited) |
 
-### Via Profile Settings
+### Via your account page
 
-You can also view credit usage in the **Profile Settings** section of your account at [app.shovels.ai](https://app.shovels.ai/profile-settings/).
+You can also view credit usage on the **Manage subscription** tab at [app.shovels.ai/account](https://app.shovels.ai/account).
 
 <Info>
 Credits reset monthly on your subscription or upgrade date.

--- a/docs/knowledge-base/cli/authentication.mdx
+++ b/docs/knowledge-base/cli/authentication.mdx
@@ -84,7 +84,7 @@ Some commands don't require authentication: `version`, `config show`, and `usage
 If you don't have an API key yet:
 
 1. [Create a free Shovels account](https://app.shovels.ai/login?mode=register)
-2. Go to [Profile Settings](https://app.shovels.ai/profile-settings/)
+2. Open the [**API key** tab](https://app.shovels.ai/account?tab=apikey)
 3. Copy your API key from the **API Key** field
 
 Free accounts include 250 requests to explore the platform.

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -18,7 +18,7 @@ A unique identifier assigned by Shovels to each distinct address in our database
 The governmental body responsible for issuing building permits in a specific geographic area. An AHJ is typically a city or county government that establishes building codes, conducts inspections, and maintains permit records. The United States has approximately 20,000 AHJs.
 
 ### API Key
-A unique authentication token required to access the Shovels API. Include it in the `X-API-Key` header of every request. Access your key at [app.shovels.ai/profile-settings](https://app.shovels.ai/profile-settings/).
+A unique authentication token required to access the Shovels API. Include it in the `X-API-Key` header of every request. Access your key at [app.shovels.ai/account](https://app.shovels.ai/account?tab=apikey).
 
 ### Active (Permit Status)
 A permit status indicating the permit has been approved and issued. Work can proceed. Defined by the `issue_date` field.

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -17,7 +17,7 @@ Shovels Online and API pricing starts with a free tier. View current plans at [s
 Yes. Shovels Online free trials include access to the last 12 months of data. The API free trial includes 250 requests with access to the full historical dataset.
 
 ### How do I cancel my subscription?
-Log in at [app.shovels.ai](https://app.shovels.ai/login) → Account Settings → Manage Subscription → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
+Log in at [app.shovels.ai/account](https://app.shovels.ai/account) → **Manage subscription** → Cancel in the Stripe billing portal. Access continues until the end of the billing period. See [How to cancel](/docs/knowledge-base/shovels-online/cancel-subscription).
 
 ### What is Shovels' refund policy?
 Refunds are reviewed case-by-case for charges within the last 30 days. Email [support@shovels.ai](mailto:support@shovels.ai) with your account email and charge details. See [Refund Policy](/docs/knowledge-base/company/refund-policy).
@@ -43,7 +43,7 @@ Search endpoints return up to 100 records per page (default: 50). Detail endpoin
 Each record returned counts against your credits. A search returning 100 permits uses 100 credits; a single permit lookup uses 1 credit.
 
 ### Where do I find my API key?
-Log in at [app.shovels.ai/profile-settings](https://app.shovels.ai/profile-settings/) and find it in the API Key section.
+Log in at [app.shovels.ai/account](https://app.shovels.ai/account?tab=apikey) and find it on the **API key** tab.
 
 ### What does a 422 error mean?
 A required parameter is missing. Most commonly, you need to resolve an address to a geo_id first using the Address Search endpoint.

--- a/docs/knowledge-base/shovels-online/cancel-subscription.mdx
+++ b/docs/knowledge-base/shovels-online/cancel-subscription.mdx
@@ -1,17 +1,16 @@
 ---
 title: "How Do I Cancel My Shovels Subscription?"
-description: "Cancel your Shovels subscription anytime from Account Settings → Manage Subscription in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
+description: "Cancel your Shovels subscription anytime from the Manage subscription tab of your account, in the Stripe billing portal. Access continues until the end of the billing period; the account then reverts to the free tier."
 ---
 
-**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai](https://app.shovels.ai/login), open Account Settings, click Manage Subscription, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
+**You can cancel your Shovels subscription at any time directly from your account — no need to contact support.** Log in at [app.shovels.ai/account](https://app.shovels.ai/account), open the **Manage subscription** tab, and confirm the cancellation in the Stripe billing portal. Your access continues until the end of the current billing period, and you won't be charged again.
 
 ## How to Cancel
 
-1. Log in at [app.shovels.ai](https://app.shovels.ai/login)
-2. Go to **Account Settings**
-3. Click **Manage Subscription**
-4. You'll be taken to the Stripe billing portal
-5. Select **Cancel Subscription** and confirm
+1. Log in at [app.shovels.ai/account](https://app.shovels.ai/account)
+2. Open the **Manage subscription** tab
+3. Click **Manage Subscription** to open the Stripe billing portal
+4. Select **Cancel Subscription** and confirm
 
 ## What Happens After You Cancel
 

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -37,7 +37,7 @@ The free API key includes 250 requests. If you use them all and need more, pleas
 
 ### API Key
 
-For any API request, you'll need to include your API key. This is available in your [Profile Settings > API Key](https://app.shovels.ai/profile-settings).
+For any API request, you'll need to include your API key. This is available in your [Account → API key](https://app.shovels.ai/account?tab=apikey).
 
 ### API Free Trial
 
@@ -188,7 +188,7 @@ Enter your API Key in the "Authentication" drop down (as shown below), and proce
 ![API Playground Authentication](/assets/screenshots/api-quickstart-guide-authentication.png)
 
 <Info>
-If you have forgotten your API key, or need one in the first place, this is available in your [Profile Settings > API Key](https://app.shovels.ai/profile-settings).
+If you have forgotten your API key, or need one in the first place, this is available in your [Account → API key](https://app.shovels.ai/account?tab=apikey).
 </Info>
 
 ### Server

--- a/docs/shovels-api-troubleshooting.mdx
+++ b/docs/shovels-api-troubleshooting.mdx
@@ -9,7 +9,7 @@ When encountering an issue with the Shovels API, whether it's authentication, ex
 
 We'll describe these steps in detail here:
 
-1. **Check your API Key**: Ensure that your API key is accurate, and matches what you see in your [Shovels Account Settings](https://app.shovels.ai/profile-settings). 
+1. **Check your API Key**: Ensure that your API key is accurate, and matches what you see in your [Account → API key](https://app.shovels.ai/account?tab=apikey). 
 2. **Check the Required Fields for the Endpoint**: The required fields may vary from endpoint to endpoint, so ensure that they're all included.
 3. **Confirm the Request Server**: Make sure that you're using the full `api.shovels.ai/v2` URL, and not just `/v2`. 
 4. **Double Check the Request Syntax**: This can vary widely based on the method you use to execute the request, but errors in query configuration can cause issues. Sometimes, the Request Examples in our [API Reference docs](/api-reference/) can help with this. 


### PR DESCRIPTION
`app.shovels.ai/profile-settings` does not resolve — confirmed by hand on 23 Aug, where it returns a 404. Eight docs links pointed at it, so a reader following "your API key is available in Profile Settings" got nothing.

The account page is now `app.shovels.ai/account`, with four tabs: **Manage subscription**, **Account details**, **API key**, **Charlie AI**.

> **Stacked on #59.** Both PRs edit `cancel-subscription.mdx:6` and `cli/authentication.mdx:86-87`, so this is based on that branch to avoid a conflict. Merge #59 first and GitHub retargets this to `main` automatically. If you'd rather have it standalone, say so and I'll rebase onto `main`.

## Destinations

Links whose copy names one specific place carry that tab's param, so the reader lands on the thing the sentence promised rather than a tab strip:

| Copy | Destination |
|---|---|
| "your API key is available in…", "access your key at…" | `app.shovels.ai/account?tab=apikey` |
| "log in at…", "cancel your subscription" | `app.shovels.ai/account` |

Eight links repointed, twelve prose references renamed from the old **Profile Settings** / **Account Settings** sections to the tabs that replaced them.

**API key tab (6)** — `shovels-api-introduction` ×2, `shovels-api-troubleshooting`, `api/basics/api-key-access`, `cli/authentication`, `glossary`, `quick-answers`

**Account page (5)** — `shovels-online/cancel-subscription` ×2, `quick-answers`, `api/basics/request-counts`

**Prose only** — `api-key-access` ("Navigate to the Profile Settings section" → "Open the **API key** tab"), `request-counts` heading, `credit-limits`, `automate-calls`; credit-usage references now name the **Manage subscription** tab, which is where the credit meter lives.

Zero `/profile-settings` occurrences remain.

## Review notes

1. **Both destinations confirmed on 23 Aug.** `/account` and `/account?tab=apikey` were clicked through and land correctly. The old `/profile-settings` returns a real 404 — worth noting because a blanket redirect used to mask exactly this kind of breakage by sending unknown paths to `/login`; that has since been fixed app-side, so a stale link now fails loudly instead of quietly.

2. **The tab params are worth a second opinion.** `?tab=apikey` is a better destination than the bare page for a reader who was told exactly where to look, but it is also more surface area to go stale — a query-param tab is precisely the kind of thing that changed silently here in the first place. The bare `/account` would be the conservative call everywhere. Happy to collapse all six if you'd rather.

3. **The cancel flow is only partly verified.** The **Manage subscription** tab is confirmed, but the account it was checked from is on the Free plan, so the "Manage Subscription → Stripe billing portal" button a paying customer sees was not visible. Those steps are carried over unchanged from the existing article rather than re-verified. Worth one look from a paid account before merge.

4. **Charlie AI tab is not documented.** There is now a Charlie AI tab showing credits used with the agent, and `charlie.mdx` says only that Charlie "uses your Shovels API credits" without saying where to see them. Deliberately left out of scope here — separate change if you want it.

Related to MAR-329 and MAR-326.