### PR TITLE
Correct the cursor pagination default page size to 10

### DIFF
--- a/docs/knowledge-base/api/basics/credit-limits.mdx
+++ b/docs/knowledge-base/api/basics/credit-limits.mdx
@@ -33,7 +33,7 @@ For full details on API usage policies, see the [API Introduction](/docs/shovels
 
 ### Records Per Call
 
-Search endpoints return up to **100 records per page** (default: 50) by setting the `size` parameter. Detail endpoints accept up to **50 IDs** per call. Each record returned counts against your credits—so a call returning 100 permits uses 100 credits.
+Search endpoints return up to **100 records per page** (default: 10) by setting the `size` parameter. Detail endpoints accept up to **50 IDs** per call. Each record returned counts against your credits—so a call returning 100 permits uses 100 credits.
 
 ### Efficient Querying
 

--- a/docs/knowledge-base/api/basics/permits-per-call.mdx
+++ b/docs/knowledge-base/api/basics/permits-per-call.mdx
@@ -12,7 +12,7 @@ The number of records you can retrieve depends on the endpoint type:
 
 ## Search Endpoints
 
-Use the `size` parameter to control how many records are returned (default: 50, max: 100):
+Use the `size` parameter to control how many records are returned (default: 10, max: 100):
 
 ```bash
 curl -X GET \

--- a/docs/knowledge-base/api/basics/query-parameters.mdx
+++ b/docs/knowledge-base/api/basics/query-parameters.mdx
@@ -24,7 +24,7 @@ Filter permits by date ranges:
 ### Pagination
 
 Control result sets:
-- `size` - Number of records per page (default: 50, max: 100)
+- `size` - Number of records per page (default: 10, max: 100)
 - `cursor` - For cursor-based pagination
 
 ## Example Requests

--- a/docs/knowledge-base/api/basics/successful-requests.mdx
+++ b/docs/knowledge-base/api/basics/successful-requests.mdx
@@ -14,7 +14,7 @@ When your request succeeds, you'll receive:
 ```json
 {
   "items": [...],
-  "size": 50,
+  "size": 10,
   "next_cursor": "...",
   "total_count": { "value": 150, "relation": "eq" }
 }

--- a/docs/knowledge-base/api/contractors/employee-data.mdx
+++ b/docs/knowledge-base/api/contractors/employee-data.mdx
@@ -16,7 +16,7 @@ The Shovels API provides a dedicated endpoint to retrieve employee information f
 ### Optional Parameters
 
 - `cursor` - For pagination through large result sets
-- `size` - Number of items per page (1-100)
+- `size` - Number of items per page (1-100, default: 10)
 
 ## Sample Request
 

--- a/docs/knowledge-base/api/decisions/searching-decisions.mdx
+++ b/docs/knowledge-base/api/decisions/searching-decisions.mdx
@@ -66,7 +66,7 @@ All filters use AND logic—a decision must match every parameter you supply.
 
 Search responses are paginated:
 
-- `size` — results per page (1–100, default 50)
+- `size` — results per page (1–100, default 10)
 - `cursor` — pass the `next_cursor` from the previous response to fetch the next page
 - `include_count` — set to `true` on the first page (no cursor) to include `total_count`. The count is exact up to 10,000; above that it is reported as a "greater than or equal to" value.
 

--- a/docs/knowledge-base/api/errors/error-handling.mdx
+++ b/docs/knowledge-base/api/errors/error-handling.mdx
@@ -18,7 +18,7 @@ An empty `items` array with a 200 response is **not an error**—it means your q
 ```json
 {
   "items": [],
-  "size": 50,
+  "size": 10,
   "next_cursor": null,
   "total_count": { "value": 0, "relation": "eq" }
 }

--- a/docs/knowledge-base/api/properties/property-search.mdx
+++ b/docs/knowledge-base/api/properties/property-search.mdx
@@ -72,7 +72,7 @@ Attribute data (value, size, year, units, type) is available for roughly 60–70
 
 Results are sorted most recently permitted first.
 
-- `size` — results per page (1–100, default 50)
+- `size` — results per page (1–100, default 10)
 - `cursor` — pass the `next_cursor` from the previous response to fetch the next page
 - `include_total_count` — set to `true` on the first page (no cursor) to include `total_count`. The count is exact up to 10,000; above that it is reported as a "greater than or equal to" value.
 

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -37,7 +37,7 @@ Internal business use: research, prospecting, lead generation, and product integ
 The free trial includes **250 requests** (each API call = 1 request, regardless of records returned). Paid plans use a credit system with custom credit limits where each record returned counts against your credits. Contact [sales@shovels.ai](mailto:sales@shovels.ai) for details.
 
 ### How many records per API call?
-Search endpoints return up to 100 records per page (default: 50). Detail endpoints accept up to 50 IDs per call.
+Search endpoints return up to 100 records per page (default: 10). Detail endpoints accept up to 50 IDs per call.
 
 ### How do API credits work?
 Each record returned counts against your credits. A search returning 100 permits uses 100 credits; a single permit lookup uses 1 credit.

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -129,7 +129,7 @@ Paginated responses use cursor-based pagination by default:
 ```json
 {
   "items": [...],
-  "size": 50,
+  "size": 10,
   "next_cursor": "eyJkYXR..." | null
 }
 ```
@@ -147,7 +147,7 @@ Cursor-based pagination uses an opaque cursor token to maintain your position in
 ```json
 {
  "items": [...],
- "size": 50,
+ "size": 10,
  "next_cursor": "eyJkYXR.lIjoiMjA.yMy0"
 }
 ```
@@ -156,11 +156,13 @@ To use cursor-based pagination:
 - For the first page: Simply make a request without any pagination parameters
 - For subsequent pages: Include the `next_cursor` value from the previous response using the `cursor` parameter
 
+Each page returns **10 records** by default. Set the `size` parameter to return up to **100** per page.
+
 Example:
 
 ```
-GET /v2/permits/search?size=10
-GET /v2/permits/search?size=10&cursor=eyJkYXR.lIjoiMjA.yMy0
+GET /v2/permits/search
+GET /v2/permits/search?cursor=eyJkYXR.lIjoiMjA.yMy0
 ```
 
 When there are no more results, the `next_cursor` value will be `null`.


### PR DESCRIPTION
Search endpoints return **10** records per page by default. The docs said 50.

This turned out to be wider than "the default isn't stated" — six pages asserted a default of 50, and four response envelopes showed `"size": 50` for a request that passed no `size` parameter. A reader sizing a credit budget or a paging loop was working from a number 5× the real one.

Based on `main`, independent of #59 and #60 — no overlapping hunks, mergeable in any order.

## Corrected from 50 to 10

| Page | Text |
|---|---|
| `api/basics/query-parameters` | "`size` - Number of records per page (default: 50, max: 100)" |
| `api/basics/permits-per-call` | "(default: 50, max: 100)" |
| `api/basics/credit-limits` | "up to **100 records per page** (default: 50)" |
| `api/decisions/searching-decisions` | "`size` — results per page (1–100, default 50)" |
| `api/properties/property-search` | "`size` — results per page (1–100, default 50)" |
| `quick-answers` | "Search endpoints return up to 100 records per page (default: 50)" |

**Response envelopes** — `shovels-api-introduction` ×2, `api/basics/successful-requests`, `api/errors/error-handling`. Each shows a generic 200 response with no request parameters, so `"size"` now reads 10.

**`api/contractors/employee-data`** gave the range `(1-100)` with no default; it now states one.

## Explainer page

`shovels-api-introduction` documented cursor pagination without ever stating the page size. It now says so once, in prose:

> Each page returns **10 records** by default. Set the `size` parameter to return up to **100** per page.

The cursor example passed `size=10` on both requests. Since the surrounding bullets describe paging *without* pagination parameters, that made the default look required — dropped, per the issue's third bullet:

```
GET /v2/permits/search
GET /v2/permits/search?cursor=eyJkYXR.lIjoiMjA.yMy0
```

## Deliberately unchanged

**The CLI's 50-record default.** `--limit 50`, `default_limit: 50` in `cli/authentication`, and the `--limit all` glossary entry describe a client-side default the CLI applies itself — a separate setting from the API parameter, and unaffected by this. Left alone rather than swept up in the find-and-replace.

**Examples that pass `size=100` on purpose** — `permits-per-call`, `query-parameters`, `automate-calls`. These demonstrate maximizing records per request, so the explicit value is the point.

## Review notes

1. **10 is taken from the issue, not verified against the API.** `api.shovels.ai` is blocked from the authoring environment, so neither a live call nor the OpenAPI spec could be read. I flagged the 50-vs-10 conflict before making these edits and was asked to proceed on the issue's number. If the real default varies by endpoint, `searching-decisions`, `property-search`, and `employee-data` are the three that would need per-endpoint values rather than a flat 10.

2. **The generated API reference is not covered by this PR and will now contradict it.** `docs.json` builds `api-reference/` from `https://api.shovels.ai/spec/v2/openapi.production.yaml`. If that spec still declares `size` default 50, the reference pages will say 50 while every prose page says 10 — a worse state than before this PR for anyone comparing the two. **This needs a matching spec change to land.** Same root cause as MAR-327, whose `is_trial` string has zero occurrences in this repo and is presumably also coming from the spec.

Closes MAR-328.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUknprcDTM1hzmff51iaQF)_