### PR TITLE
Add the interface lineup to the differentiators

### DIFF
--- a/docs/knowledge-base/getting-started/key-differentiators.mdx
+++ b/docs/knowledge-base/getting-started/key-differentiators.mdx
@@ -1,9 +1,9 @@
 ---
 title: "What Makes Shovels Different From Other Permit Data Providers?"
-description: "Shovels differentiates with: 1) USPS-standardized addresses, 2) contractor grouping linking related businesses, 3) 98% AI accuracy, 4) sophisticated deduplication."
+description: "Shovels differentiates with: 1) USPS-standardized addresses, 2) contractor grouping linking related businesses, 3) 98% AI accuracy, 4) sophisticated deduplication, 5) every interface included on every plan."
 ---
 
-**Shovels stands out from other permit data providers through four key differentiators: (1) USPS-standardized, geocoded addresses, (2) comprehensive contractor data with parent-company grouping, (3) 98% classification accuracy using AI validated by industry experts, and (4) sophisticated deduplication that maintains consistent IDs across updates.** We source directly from jurisdictions—never from third-party resellers.
+**Shovels stands out from other permit data providers through five key differentiators: (1) USPS-standardized, geocoded addresses, (2) comprehensive contractor data with parent-company grouping, (3) 98% classification accuracy using AI validated by industry experts, (4) sophisticated deduplication that maintains consistent IDs across updates, and (5) every way of reaching the data included on every plan.** We source directly from jurisdictions—never from third-party resellers.
 
 ## Key Differentiators
 
@@ -35,6 +35,19 @@ Our system maintains a unique identifier for each permit and updates records as 
 - Consistent permit IDs throughout the lifecycle
 - No duplicate records from status updates
 - Reliable tracking across data refreshes
+
+### 5. Every Interface Included
+
+You are not buying a seat in one tool. Every plan includes the same ways of reaching the data, and they draw on one shared credit balance—so you can move between them without changing plans or negotiating an add-on:
+
+- **Shovels Online** — search, filter, map, and export in the browser
+- **Shovels API** — REST endpoints for integrations and automated workflows
+- **Shovels CLI** — a single binary with JSON output, built for terminals and AI agents
+- **Charlie** — the AI agent inside Shovels Online, opened with the **Agent** button
+
+See [choosing an interface](/docs/knowledge-base/getting-started/pricing-structure) for which one fits a given job.
+
+Hosted **GIS layers** for ArcGIS and QGIS sit outside the plan lineup: they are scoped and provisioned by our GIS team, and are also available as an Enterprise Data License delivery format.
 
 <Info>
 Learn more about our data quality approach in our [data labeling process](/docs/knowledge-base/data/quality/labeling-process) article.


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Closes the Wave 1 leftover *`getting-started/key-differentiators` — align to refreshed feature lineup (Charlie, CLI, GIS, Data)*, which moved to Wave 2 when it was coupled to the Charlie reframe. That gate is gone — the `charlie.shovels.ai` framing was cleared by #44 and Charlie's wording settled in #58.

The article's four differentiators are all **data quality** — standardized addresses, contractor grouping, 98% classification accuracy, deduplication. Nothing about how a customer actually reaches that data, so the refreshed feature lineup was absent entirely: no mention of Charlie, the CLI, or GIS.

**Changes** — `getting-started/key-differentiators.mdx`, +14/-2:
- New **5. Every Interface Included** section: Shovels Online, the API, the CLI, Charlie, and GIS layers — all included on every plan, drawing on one shared credit balance.
- Lede and `description` updated from four differentiators to five.
- Cross-links `pricing-structure`'s "Choosing an Interface" table (added in #50) so the two articles agree rather than restating each other.

Grounded in the pricing page's own claim — *"Every interface is included with every plan. The web app, API, CLI, and AI assistant all share one credit balance"* — rather than invented positioning. GIS is described as hosted feature layers for ArcGIS/QGIS, per `features/gis`. Charlie is "opened with the **Agent** button", consistent with #58.

The framing is deliberately the differentiator rather than the feature list: providers that sell each surface separately, or per seat, are the contrast this article exists to draw.

**Deliberately out of scope:** the site also markets **SOC 2 Type II on every plan** — *"the security and compliance controls enterprise buyers ask for, on the free tier too."* Arguably a stronger differentiator than anything currently listed, but it is security rather than feature lineup. Happy to add it as a sixth if wanted.

**Validation:** `mint broken-links` (4.2.3) — clean. Rendered locally. No overlap with the two open PRs (#49, #52), which do not touch this file.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.