### PR TITLE
Repoint the permit availability link at its page

### DIFF
--- a/docs/foundations-building-blocks.mdx
+++ b/docs/foundations-building-blocks.mdx
@@ -34,7 +34,7 @@ That is a treasure trove of information, and when analyzed at scale allows for s
 
 Permit data is extremely useful in too many ways to list here, but if you want to know the status and details of a project, then the permit is the best place to start. 
 
-For more information on how we obtain our permit data (and the challenges that accompany that), see our section on [Permit Availability](/foundations-permit-availability).
+For more information on how we obtain our permit data (and the challenges that accompany that), see our section on [Permit Availability](/docs/foundations-understanding-permits).
 
 #### Permit Categories
 


### PR DESCRIPTION
Incidental broken-link fix found during the KB refresh (MAR-267) — same shape as #47.

`foundations-building-blocks.mdx` linked to `/foundations-permit-availability`, which does not exist. The article it means is `foundations-understanding-permits.mdx`, whose frontmatter still reads `title: Permit Availability` — the file was renamed and this link never followed.

**Changes** — `docs/foundations-building-blocks.mdx`, +1/-1: `/foundations-permit-availability` → `/docs/foundations-understanding-permits`.

Confirmed the right target rather than guessed: three other links in the docs already point at `/docs/foundations-understanding-permits`, so this was the last one the rename left behind, and the link text "Permit Availability" still matches the target's title so the label needs no change.

**This clears the last genuine broken link in the repo.** `mint broken-links` (4.2.3) now reports only the known `/api-reference` false positives — those pages are generated from the OpenAPI spec, so the static checker cannot see them and they resolve 200 live.

Note this file belongs to MAR-277 (Building Blocks data-model accuracy), which is still blocked on Decisions and Properties. The link break is independent of that work, so it is fixed here rather than waiting.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.