### PR TITLE
Describe EDL deliveries as twice monthly

### DIFF
--- a/docs/knowledge-base/data/quality/refresh-frequency.mdx
+++ b/docs/knowledge-base/data/quality/refresh-frequency.mdx
@@ -39,6 +39,6 @@ If you cache IDs and encounter not-found responses, use other record attributes 
 
 ## Related Articles
 
-- [EDL monthly deliveries](/docs/knowledge-base/edl/monthly-deliveries)
+- [EDL deliveries](/docs/knowledge-base/edl/monthly-deliveries)
 - [Data sources](/docs/knowledge-base/data/quality/data-sources)
 - [Why am I getting so few results?](/docs/knowledge-base/data/quality/few-results)

--- a/docs/knowledge-base/edl/data-formats.mdx
+++ b/docs/knowledge-base/edl/data-formats.mdx
@@ -48,4 +48,4 @@ Contact your account representative to discuss which format works best for your 
 ## Related Articles
 
 - [EDL overview](/docs/knowledge-base/edl/overview)
-- [Monthly deliveries](/docs/knowledge-base/edl/monthly-deliveries)
+- [EDL deliveries](/docs/knowledge-base/edl/monthly-deliveries)

--- a/docs/knowledge-base/edl/monthly-deliveries.mdx
+++ b/docs/knowledge-base/edl/monthly-deliveries.mdx
@@ -1,13 +1,13 @@
 ---
-title: "How Monthly EDL Deliveries Work"
-description: "Understand how Shovels delivers monthly data updates to EDL customers using the overwrite model while maintaining ID consistency."
+title: "How EDL Deliveries Work"
+description: "Understand how Shovels delivers twice-monthly data updates to EDL customers using the overwrite model while maintaining ID consistency."
 ---
 
 For Enterprise Data License (EDL) customers, Shovels employs an **overwrite approach** when pushing data to your data warehouse.
 
 ## How It Works
 
-Each monthly delivery is treated as a **fresh table**, completely replacing the previous month's data with the updated dataset.
+Each delivery is treated as a **fresh table**, completely replacing the previous delivery's data with the updated dataset.
 
 ### Benefits
 
@@ -23,7 +23,7 @@ This approach simplifies data management by:
 - Address IDs
 - Contractor IDs
 
-This consistency ensures that any scripts, analyses, or processes relying on these IDs won't be impacted by the monthly refresh.
+This consistency ensures that any scripts, analyses, or processes relying on these IDs won't be impacted by a refresh.
 
 <Info>
 The stability of our ID system allows customers to build reliable data pipelines and maintain referential integrity.
@@ -31,7 +31,7 @@ The stability of our ID system allows customers to build reliable data pipelines
 
 ## What's Included
 
-Each monthly delivery includes:
+Each delivery includes:
 - All historical data
 - New permits added since last delivery
 - Updates to existing records (status changes, etc.)
@@ -47,9 +47,7 @@ For customers who need to track changes between deliveries, we recommend:
 
 ## Delivery Schedule
 
-EDL data is refreshed on the same schedule as our main database:
-- 1st of the month
-- 15th of the month
+Standard delivery is **twice a month**, on the same schedule as our main database. Custom delivery cadences are available for enterprise contracts with specific SLA requirements — contact [sales@shovels.ai](mailto:sales@shovels.ai) to discuss one.
 
 ## Related Articles
 

--- a/docs/knowledge-base/edl/overview.mdx
+++ b/docs/knowledge-base/edl/overview.mdx
@@ -11,7 +11,7 @@ The **EDL** is ideal when you need:
 - Every contractor across multiple counties
 - All available data fields
 - Data delivered directly to your data warehouse
-- Complete monthly dataset updates
+- Complete dataset updates twice a month
 - Complex SQL joins and queries
 
 The **API** is better for:
@@ -61,7 +61,7 @@ Flat file deliveries contain significantly more data fields than API access, inc
 
 Direct data delivery eliminates API latency concerns for large-scale analysis.
 
-### Monthly Updates
+### Twice-Monthly Updates
 
 Each delivery includes all historical data plus new permits and updates, providing a complete and current view.
 
@@ -75,6 +75,6 @@ Contact [sales@shovels.ai](mailto:sales@shovels.ai) to discuss your enterprise d
 
 ## Related Articles
 
-- [Monthly deliveries explained](/docs/knowledge-base/edl/monthly-deliveries)
+- [EDL deliveries explained](/docs/knowledge-base/edl/monthly-deliveries)
 - [Record tracking](/docs/knowledge-base/edl/record-tracking)
 - [Pricing structure](/docs/knowledge-base/getting-started/pricing-structure)

--- a/docs/knowledge-base/edl/record-tracking.mdx
+++ b/docs/knowledge-base/edl/record-tracking.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tracking New vs Modified Records in EDL"
-description: "Learn how to use first_seen_date and other fields to identify new versus pre-existing records in monthly EDL data deliveries."
+description: "Learn how to use first_seen_date and other fields to identify new versus pre-existing records in EDL data deliveries."
 ---
 
-For EDL customers receiving monthly data overwrites, tracking whether a record is new versus pre-existing and modified can be accomplished using the `first_seen_date` field.
+For EDL customers receiving twice-monthly data overwrites, tracking whether a record is new versus pre-existing and modified can be accomplished using the `first_seen_date` field.
 
 ## Using first_seen_date
 
@@ -48,5 +48,5 @@ We're actively working on enhancing our data delivery system to include explicit
 
 ## Related Articles
 
-- [Monthly deliveries](/docs/knowledge-base/edl/monthly-deliveries)
+- [EDL deliveries](/docs/knowledge-base/edl/monthly-deliveries)
 - [EDL overview](/docs/knowledge-base/edl/overview)

--- a/docs/knowledge-base/glossary.mdx
+++ b/docs/knowledge-base/glossary.mdx
@@ -95,7 +95,7 @@ A permit status indicating the project is complete and has passed final inspecti
 The date when a permit received final approval after passing all required inspections.
 
 ### First Seen Date
-The date when Shovels first discovered a permit in our data collection process. Used by EDL customers to identify new records in monthly deliveries.
+The date when Shovels first discovered a permit in our data collection process. Used by EDL customers to identify new records in each delivery.
 
 ## G
 

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -76,7 +76,7 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 
 ### Enterprise Data (EDL)
 - [When should I use EDL vs API?](/docs/knowledge-base/edl/overview)
-- [How do monthly deliveries work?](/docs/knowledge-base/edl/monthly-deliveries)
+- [How do EDL deliveries work?](/docs/knowledge-base/edl/monthly-deliveries)
 - [How do I track new vs modified records?](/docs/knowledge-base/edl/record-tracking)
 
 ## Need More Help?

--- a/docs/knowledge-base/quick-answers.mdx
+++ b/docs/knowledge-base/quick-answers.mdx
@@ -225,7 +225,7 @@ Parquet (preferred), CSV, or JSON. Typical delivery size is 15-20 GB.
 ### Where can data be delivered?
 Snowflake, BigQuery, Databricks, or as downloadable files.
 
-### How do I track new records in monthly deliveries?
+### How do I track new records in EDL deliveries?
 Use the `first_seen_date` field. Records with `first_seen_date` after your last delivery are new.
 
 ---


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Closes the `edl/monthly-deliveries` + `edl/record-tracking` items from the 🟢 verify list.

EDL delivers on the **same twice-monthly schedule as the main database** — confirmed against `/solutions/data-feed`, which states it in four places: a feature block ("Choose standard twice-monthly updates or a custom delivery schedule"), a calendar graphic labelled "1st & 15th standard delivery", and two FAQ answers. So EDL is not on a separate cadence, which was worth verifying before assuming.

**The article already contradicted itself.** Its Delivery Schedule section listed the 1st and 15th while the title, description and three body sentences described a monthly cycle.

**The consequence was in the mechanic, not just the label.** "Each monthly delivery is treated as a fresh table, completely replacing **the previous month's** data" tells a warehouse customer their table turns over half as often as it does. That is the line worth fixing; the overwrite model itself — fresh table, stable IDs across releases — is accurate and unchanged.

**Changes** — +17/-19 across 8 files:
- `edl/monthly-deliveries.mdx`: title → "How EDL Deliveries Work"; description → twice-monthly; "previous month's data" → "previous delivery's data"; two further body sentences.
- **Delivery Schedule** rewritten as prose rather than a date list — the docs describe the cadence rather than naming the 1st and 15th, since the exact days vary between cycles (same convention as #54). It now also records the **custom cadence available on enterprise contracts with SLA requirements**, which the site advertises and the article omitted entirely.
- `edl/record-tracking.mdx` ×2, `edl/overview.mdx` ×2 ("Complete monthly dataset updates", "### Monthly Updates"), `glossary.mdx` — sibling articles carrying the same framing.
- Five inbound link labels: "Monthly deliveries" → "EDL deliveries" (`index`, `record-tracking`, `overview`, `data-formats`, `refresh-frequency`), plus the `quick-answers` heading.

**The slug stays `edl/monthly-deliveries`**, deliberately. Renaming it would need a `docs.json` redirect for a public URL that EDL customers may have bookmarked, and the tradeoff was not worth it. So the URL still says "monthly" while the page no longer does — noted here so it is a known decision rather than an oversight.

**Context worth having:** this file had not been edited since the original HubSpot migration (`6fb1743`), making it the least-reviewed content in the KB. I read it in full rather than grep-swapping, which is how the custom-cadence gap surfaced. One thing I left alone but flag: `record-tracking.mdx` promises "We're actively working on enhancing our data delivery system to include explicit change tracking flags in future releases" — a forward-looking commitment from the HubSpot era that someone should confirm is still true.

**Validation:** `mint broken-links` (4.2.3) — no new flags. All eight pages rendered locally. Verified to merge clean against #49, #52, #63 and #64, including the two that also touch `quick-answers`.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.