### PR TITLE
Add plan-choice and API-vs-EDL guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -205,6 +205,8 @@
                 "pages": [
                   "docs/knowledge-base/getting-started/free-trial-guide",
                   "docs/knowledge-base/getting-started/pricing-structure",
+                  "docs/knowledge-base/getting-started/choosing-a-plan",
+                  "docs/knowledge-base/getting-started/api-vs-edl",
                   "docs/knowledge-base/getting-started/key-differentiators"
                 ]
               },

--- a/docs/knowledge-base/getting-started/api-vs-edl.mdx
+++ b/docs/knowledge-base/getting-started/api-vs-edl.mdx
@@ -1,0 +1,59 @@
+---
+title: "Should I Use the API or an Enterprise Data License?"
+description: "The Shovels API retrieves records on demand and is metered per record. An Enterprise Data License delivers the full dataset to your warehouse on a schedule, with fields the API doesn't expose."
+sidebarTitle: "API vs EDL"
+---
+
+**Use the API when your application asks for records as it needs them. Use an Enterprise Data License (EDL) when your team wants the whole dataset sitting in your own warehouse.** The difference is not how much data you can get — it's whether Shovels answers your queries or hands you the tables.
+
+## The Short Version
+
+| | Shovels API | Enterprise Data License |
+|---|---|---|
+| **How you get data** | Request records as you need them | The full dataset delivered to your warehouse |
+| **Where it lives** | Shovels' servers | Snowflake, BigQuery, Databricks, or parquet files |
+| **How it's priced** | Credits, one per record | A contract sized to your needs |
+| **Fields** | The documented API schema | More, including fields the API doesn't expose |
+| **Freshness** | Current as of the last refresh, on request | Delivered twice a month, or a custom cadence |
+| **Best for** | Product features, lookups, automated workflows | Bulk analysis, modelling, joins against your own data |
+
+## Choose the API When
+
+- You are building a product feature and need permits for one address, contractor, or city at a time
+- Your queries are unpredictable — you don't know in advance which records you'll want
+- You want to start today without a contract, on any plan including Free
+- Your volumes are measured in thousands of records rather than the whole country
+
+The API is metered per record, so cost tracks usage. That works well when usage is spiky or narrow, and badly when you intend to pull everything.
+
+## Choose an EDL When
+
+- You need **every** record in a category — every contractor across a state, every permit in a metro — rather than a selection
+- You want to join Shovels data against your own tables in SQL
+- You need fields the API doesn't expose, such as applicant and owner email addresses and additional property detail
+- You are training models or running analysis where paging through an API would be the bottleneck
+- You want the data in Snowflake, BigQuery, Databricks, or as parquet files in your own object storage
+
+## The Practical Tells
+
+A few signals that usually settle it:
+
+- **If you find yourself planning to page through the API to download everything**, you want an EDL. That is the shape the API is worst at.
+- **If you need one record in response to a user action**, you want the API. A warehouse copy can't answer a live lookup.
+- **If you need a field you can't find in the API reference**, ask about an EDL — the delivered dataset is wider.
+- **If you're not sure yet**, start on the API. It costs nothing to try on the Free plan, and what you learn about your own access pattern is the best input to an EDL conversation.
+
+Plenty of customers use both: the API inside a product, and an EDL feeding the analytics that sit behind it.
+
+## Getting Started
+
+The API is available on every plan — [create an account](https://app.shovels.ai/login?mode=register) and your key is on the API key tab.
+
+An EDL is a contract, so it starts with a conversation. Email [sales@shovels.ai](mailto:sales@shovels.ai); a sample dataset can be delivered into your own warehouse environment so your team can evaluate coverage and schema before committing.
+
+## Related Articles
+
+- [What is Shovels EDL?](/docs/knowledge-base/edl/overview)
+- [How EDL deliveries work](/docs/knowledge-base/edl/monthly-deliveries)
+- [Which Shovels plan is right for me?](/docs/knowledge-base/getting-started/choosing-a-plan)
+- [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)

--- a/docs/knowledge-base/getting-started/choosing-a-plan.mdx
+++ b/docs/knowledge-base/getting-started/choosing-a-plan.mdx
@@ -1,0 +1,59 @@
+---
+title: "Which Shovels Plan Is Right for Me?"
+description: "Pick a Shovels plan by what you need: how far back your data goes, whether you export, how many records you pull each month, and how many seats you need."
+sidebarTitle: "Choosing a Plan"
+---
+
+**Most people can pick a plan by answering four questions: how far back you need data, whether you need to export it, how many records you pull each month, and how many people need access.** Every plan includes every interface, so you are not choosing between the web app, the API, the CLI, and Charlie — you get all of them either way.
+
+## Start With These Four Questions
+
+### 1. How far back do you need permits to go?
+
+In Shovels Online, the Free plan covers the **last 12 months**. Paid plans open the full history — on average 25 years or more, depending on the jurisdiction.
+
+Through the API this limit doesn't apply: every plan, including Free, can query the full historical dataset.
+
+### 2. Do you need to export records?
+
+CSV export from Shovels Online **requires a paid plan**. On Free you can search, filter, view details, and use the map, but the export action is unavailable.
+
+If your work ends in a spreadsheet, a CRM, or a list you hand to someone else, you need a paid plan. If you are answering questions on screen, Free may be enough.
+
+### 3. How many records will you pull each month?
+
+Plans are sized in credits, and one credit is one record — spent when you retrieve records through the API or export them from Shovels Online. Browsing and asking Charlie don't spend credits.
+
+Estimate the records, not the queries: a single export of 5,000 contractors costs 5,000 credits, while a month of searching costs nothing. See [shovels.ai/pricing](https://www.shovels.ai/pricing) for each plan's monthly allowance.
+
+### 4. How many people need their own login?
+
+Free and Basic are single-seat. Pro covers a small team, and Enterprise is sized to your organisation. Current seat counts are on [shovels.ai/pricing](https://www.shovels.ai/pricing).
+
+## What Doesn't Vary by Plan
+
+These are the same whichever plan you choose, so they shouldn't drive the decision:
+
+- **Every interface.** Shovels Online, the API, the CLI, and Charlie are included on all plans and share one credit balance.
+- **The full dataset.** No dataset is gated behind a higher plan.
+- **Data freshness.** Every plan gets the same twice-monthly refresh.
+- **Security posture.** Every plan runs on the same SOC 2 Type II audited infrastructure.
+
+## When a Plan Isn't the Answer
+
+GIS layers are also outside the plan lineup. Hosted feature layers for ArcGIS or QGIS are scoped and provisioned by the Shovels GIS team rather than switched on by a plan — [talk to us](https://www.shovels.ai/contact) about the geographies and permit types you need.
+
+If you need the **entire dataset in your own warehouse** — every permit, contractor, property, and resident record, including fields the API doesn't expose — that is an [Enterprise Data License](/docs/knowledge-base/edl/overview), not a plan. It is a contract rather than a subscription, so it starts with a conversation: [sales@shovels.ai](mailto:sales@shovels.ai).
+
+See [Should I use the API or an EDL?](/docs/knowledge-base/getting-started/api-vs-edl) if you're weighing the two.
+
+## Still Not Sure?
+
+Start on Free. It doesn't expire, needs no credit card, and you can upgrade once you know which limit you hit first — that limit usually tells you which plan you need.
+
+## Related Articles
+
+- [How much does Shovels cost?](/docs/knowledge-base/getting-started/pricing-structure)
+- [What's included in the Free plan?](/docs/knowledge-base/getting-started/free-trial-guide)
+- [Should I use the API or an EDL?](/docs/knowledge-base/getting-started/api-vs-edl)
+- [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Two of the three **net-new articles**: *"Which plan is right for me?"* and *"API vs EDL."* The third — the consumer "How credits work" explainer — is held until the `request-counts` credit-model fix lands, so the two agree rather than contradict.

**New files** (+116, 2 articles), plus two `docs.json` nav entries in Getting Started after `pricing-structure`:
- `getting-started/choosing-a-plan.mdx` — "Which Shovels Plan Is Right for Me?"
- `getting-started/api-vs-edl.mdx` — "Should I Use the API or an Enterprise Data License?"

**The design constraint was not duplicating `pricing-structure`**, which already lists the plan lineup and carries a two-bullet API-vs-EDL aside. So neither article restates the catalogue:

**Choosing a Plan** answers *which one fits me*, structured as the four questions that actually separate the tiers — how far back you need permits, whether you need to export, monthly record volume, and seats. It states the structural differences (Free is 12 months in Shovels Online but full history through the API; export requires a paid plan; browsing and Charlie spend no credits) and links `shovels.ai/pricing` for every volatile figure, per the name-tiers-and-link approach from #46. It also has a "what doesn't vary by plan" section, since the things people assume are gated — datasets, refresh cadence, SOC 2 posture — are not.

**API vs EDL** turns the aside into a decision: a comparison table on how you get data, where it lives, pricing model, field coverage and freshness, then "the practical tells". The sharpest is *if you find yourself planning to page through the API to download everything, you want an EDL — that is the shape the API is worst at.* It also says plenty of customers use both, and that a sample dataset can be delivered into your own warehouse before committing.

---

**A correction that also affected #63.** The first draft of both this PR and #63 listed **GIS layers** as an interface "included on every plan". That is wrong. Per [features/gis](https://www.shovels.ai/features/gis), GIS access is provisioned, not entitled — *"Talk to our GIS team about the geographies, permit types, and layers you need… We publish your hosted feature layers and share credentials"* — and the pricing page's "every interface" sentence names exactly four: *"The web app, API, CLI, and AI assistant all share one credit balance."* GIS is absent from it, and the GIS page calls layers *"one delivery format"* of the Data Feed.

Both are corrected: the four genuinely plan-included interfaces are listed as such, and GIS is described separately as scoped by the GIS team and available as an EDL delivery format. #63 has been force-pushed with the same fix. Left alone, it would have promised paying customers access their subscription does not grant.

---

**These articles are reachable through the nav only, deliberately.** Inbound links belong in `getting-started/pricing-structure.mdx` (from its Plans section and its API-vs-EDL aside) and `knowledge-base/index.mdx` — both of which sit inside #49, so editing them here would manufacture a merge conflict across in-flight branches. **Follow-up once #49 merges:** cross-link both articles from `pricing-structure` and `index`, and consider replacing `pricing-structure`'s two-bullet API-vs-EDL `<Info>` with a pointer to the new article now that one exists.

**Validation:** `docs.json` re-serialised without reformatting (diff is exactly +2 lines) and parses. `mint broken-links` (4.2.3) — every link in both new articles resolves; the only flag is the pre-existing `foundations-building-blocks` break that #64 fixes. Both pages rendered locally. Verified to merge clean against all five other open PRs (#49, #52, #63, #64, #65).

Linear: MAR-267. Reviewer: @rbucks — merge when ready.