### PR TITLE
Flag which docs pages are generated from the API spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
-# Project Engineering Standards
+# Documentation Repository Standards
 
-Project-wide coding standards and conventions for this codebase.
+Standards and conventions for `shovels-docs`, the public-facing Shovels documentation site.
+
+This is a **Mintlify documentation site**. It contains MDX content, `docs.json` configuration,
+and static assets. There is no application code here: no Python, no test suite, no build
+pipeline beyond Mintlify itself.
 
 ---
 
@@ -21,266 +25,6 @@ We're colleagues working together - no formal hierarchy.
 - You search your journal when you're trying to remember or figure stuff out
 
 **Rule #1**: If you want exception to ANY rule, YOU MUST STOP and get explicit permission from the user first. BREAKING THE LETTER OR SPIRIT OF THE RULES IS FAILURE.
-
----
-
-## Software Design Philosophy
-
-**YAGNI**: The best code is no code. Don't add features we don't need right now.
-
-**Design principles:**
-- Design for extensibility and flexibility
-- Prefer simple, clean, maintainable solutions over clever or complex ones, even if the latter are more concise or performant
-- Readability and maintainability are primary concerns
-- Good naming is very important. Name functions, variables, classes, etc so that the full breadth of their utility is obvious
-- Reusable, generic things should have reusable generic names
-
----
-
-## Code Implementation Standards
-
-**Atomic changes:**
-- YOU MUST ALWAYS break a plan into small atomic and fully functional steps
-- Each step should encapsulate the smallest reasonable change to the code
-- Each step should include unit tests. All tests should pass
-- Each such step should be wrapped into a commit
-- YOU MUST ALWAYS adhere to clean git history principle: we want to be able to track atomic changes and be able to git bisect to find elusive bugs
-- YOU MUST ALWAYS perform prefactory refactoring (preparatory refactoring) if you're working on a complex task that requires this in order to follow our rules
-
-**Code quality:**
-- YOU MUST make the SMALLEST reasonable changes to achieve the desired outcome
-- YOU MUST WORK HARD to reduce code duplication, even if the refactoring takes extra effort
-- YOU MUST MATCH the style and formatting of surrounding code, even if it differs from standard style guides. Consistency within a file trumps external standards
-- YOU MUST NOT change whitespace that does not affect execution or output. Otherwise, use a formatting tool
-- Follow Python 3.11+ standards with Google's PEP8 (100 char line limit)
-
-**Test requirements:**
-- YOU MUST run and verify ALL specified tests pass before committing
-- If tests fail, timeout, or cannot run: YOU MUST STOP immediately and consult user
-- NEVER proceed with "tests will be verified later" or "tests probably work"
-- Test evidence: Run command cleanly (success = no error field populated in tool response)
-- ❌ NEVER use `;` followed by `echo "Exit code: $?"` - triggers approval prompts repeatedly
-- ✅ The Bash tool automatically shows command success/failure - no manual exit code checking needed
-- If you lack observability into why tests fail (no server logs, etc): YOU MUST STOP and consult user
-- DO NOT investigate test failures outside the scope of your task - consult user first
-
-**What to NEVER do:**
-- YOU MUST NEVER make code changes unrelated to your current task. If you notice something that should be fixed but is unrelated, document it in your journal rather than fixing it immediately
-- YOU MUST NEVER throw away or rewrite implementations without EXPLICIT permission. If you're considering this, YOU MUST STOP and ask first
-- YOU MUST get user's explicit approval before implementing ANY backward compatibility changes
-- NEVER implement a mock mode for testing or for any purpose. We always use real data and real APIs, never mock implementations
-- NEVER name things as "improved" or "new" or "enhanced", etc. Code naming should be evergreen. What is new someday will be "old" someday
-
-**Comments and documentation:**
-- YOU MUST explain WHY (complex business logic) over WHAT (code should be simple to speak for itself) in comments
-- YOU MUST NEVER add comments about what used to be there or how something has changed
-- YOU MUST NEVER refer to temporal context in comments (like "recently refactored" "moved") or code. Comments should be evergreen and describe the code as it is
-
----
-
-## Unit Testing Principles
-
-When reviewing or writing unit tests:
-
-**YOU MUST ALWAYS:**
-- Inject all dependencies via constructor parameters, method parameters, or test fixtures
-- Maintain clear separation between test and production code
-- Focus on observable results, state changes, and return values
-- Test public interfaces and contracts, not internal implementation details
-- Verify external interactions through their results, not method calls
-- Write tests that survive refactoring when behavior remains unchanged
-- Test all execution paths and conditional branches
-- Use clear descriptive names: `test_method_scenario` or `test_behavior_when_condition`
-- Use one logical assertion per test case
-- Follow: verbose is better than complex - tests can repeat themselves for readability
-- One test case per input example - each specific input-output pair gets its own test
-- Test failures should make it immediately clear why they failed
-
-**YOU MUST NEVER:**
-- Use `unittest.mock.patch`, monkeypatch, or global variable modifications (except in CLI/integration tests where mocking AWS/external services is necessary)
-- Implement complex logic in tests - avoid loops, conditionals, or "tests for tests"
-- Test internal method call sequences using assert_called_with or similar patterns
-- Miss edge cases or error scenario coverage
-- Test with unclear purpose or multiple unrelated assertions
-- Hard-code dependencies in test setup
-
-**Private method testing guidance:**
-- Prefer testing through public interfaces when practical
-- Test private methods directly when:
-  1. They have complex logic with many edge cases (especially security-critical functions like SQL escaping)
-  2. Failure would be hard to diagnose through public interface alone
-  3. The private method is a pure utility function
-- If a private method needs extensive testing, consider extracting to a public utility module (e.g., `api/app/lib/sql/escaping.py`)
-
----
-
-## Shared Code Organization
-
-Follow these conventions for organizing shared code:
-
-### Three Levels of Sharing
-
-1. **Repo-level libraries** (`api/app/lib/`)
-   - Used by 3+ packages across different domains
-   - Examples: `lib/pagination/`, `lib/geo/`, `lib/csv/`
-   - Pure utilities with no domain-specific coupling
-
-2. **Package-level helpers** (`package/helpers.py`)
-   - Used by multiple modules within one package
-   - Examples: `contractors/helpers.py`, `geo_metrics/helpers.py`
-   - Domain-specific utilities (query builders, formatters)
-
-3. **Inline utilities**
-   - Used by single module only
-   - Keep in the module file itself
-   - Extract to helpers.py if ≥3 functions or >50 LOC
-
-### Decision Criteria
-
-**Move to `lib/` when:**
-- Function is pure utility (no domain coupling)
-- Used across 3+ different packages
-- Consolidates duplication (e.g., geo ID formatting used by all geo_* packages)
-
-**Keep in `package/helpers.py` when:**
-- Domain-specific (e.g., contractor-specific query logic)
-- Used by 2+ modules in same package only
-
-**Keep inline when:**
-- Single module usage
-- < 50 LOC of shared code
-
----
-
-## Python Execution
-
-**ALWAYS use absolute imports** in this project.
-**ALWAYS run `uv run`. NEVER execute `python` directly.**
-
-`uv` automatically adds project root to `PYTHONPATH`.
-
----
-
-## Version Control & Git
-
-**Commit frequency:**
-- YOU MUST commit frequently throughout the development process, even if your high-level tasks are not yet done
-
-**Pre-commit hooks:**
-- NEVER SKIP OR EVADE OR DISABLE A PRE-COMMIT HOOK
-
-**Staging changes:**
-- NEVER use `git add -A` unless you've just done a `git status` - You don't want to add random test files to the repo
-
-**Temporal context:**
-- YOU MUST NEVER leave temporal context in git description (like "recently refactored" "moved") or code
-- Body should be evergreen and describe the code as it is
-- If you name something "new" or "enhanced" or "improved", you've probably made a mistake and MUST STOP and ask me what to do
-
----
-
-## Commit Message Guidelines
-
-Follow these rules for great Git commit messages:
-
-### Format Rules
-
-1. **Separate subject from body** with a blank line
-2. **Limit subject line to 50 characters** - forces concise, thoughtful descriptions
-3. **Capitalize the subject line** - begin with capital letter
-4. **No period at end** of subject line - saves space
-5. **Use imperative mood** in subject line - write as command ("Add feature" not "Added feature")
-6. **Wrap body at 72 characters** - ensures readability across tools
-7. **Explain what and why, not how** - focus on reasons for change and problem solved
-
-### Content Rules
-
-** NEVER include:**
-- Process tracking: "Step 5", "Phase 2", "Task ABC-123"
-- Ticket IDs: ENG-123, JIRA-456, issue #789, Linear references
-- Metrics: "200 LOC", "95% coverage", "within target"
-- Temporal context (past): "recently refactored", "previously moved", "used to be"
-- Temporal context (future): "will fix later", "next step", "TODO", "this prepares for"
-- Self-praise: "successfully", "perfect", "excellent"
-- Irrelevant details: test counts, files changed, tool promotions
-- Verbose bloat: Restating subject line, over-explaining obvious changes
-
-** ALWAYS include:**
-- Technical rationale (WHY architecturally)
-- Timeless context (readable in 6 months without project docs)
-- Tradeoffs (if accepting debt, explain)
-
-### Examples
-
-**Bad - Temporal context (future):**
-```
-Create lib/geo/formatting module
-
-Extract formatting utilities to shared library.
-
-Next step: Update route modules to import from lib/geo.
-```
-**BAD** - "Next step" refers to future work - not evergreen
-
-**Bad - Temporal context (past):**
-```
-Move formatting functions to lib/geo
-
-These were previously in geo_search/addresses.py but
-recently refactored to be shared across modules.
-```
-**BAD** - "previously", "recently refactored" - refers to history
-
-**Bad - Process tracking:**
-```
-Extract addresses endpoint (Step 2, Phase 4.1 complete)
-
-Files changed: 3, Tests: 15 passing
-```
-**BAD** - "Step 2", "Phase 4.1", metrics
-
-**Bad - Ticket references and verbose bloat:**
-```
-Update geo routes to import from lib/geo
-
-Replace local function definitions with imports from centralized
-api.app.lib.geo.formatting module.
-
-This follows ENG-613 Goal #3 to consolidate duplicated code into
-well-defined libraries. All route modules now use shared geo
-utilities instead of maintaining local copies.
-```
-**BAD** - "ENG-613" ticket reference, verbose restatement of obvious
-
-**Good - Evergreen, explains WHY:**
-```
-Extract addresses endpoint to dedicated module
-
-Move address search logic to addresses.py following Single
-Responsibility Principle. Shared helpers remain in legacy
-file temporarily to support remaining endpoints during
-incremental migration.
-```
-**GOOD** - Timeless context, explains architectural reasoning
-
-**Good - Concise architectural context:**
-```
-Update geo routes to import from lib/geo
-
-Replace local function definitions with imports from centralized
-api.app.lib.geo.formatting module. Consolidates duplicate utility
-code across route packages following three-level sharing convention.
-```
-**GOOD** - Clear WHY (consolidation), no ticket refs, no bloat
-
-**Key principles:**
-- Subject line communicates the change clearly
-- Body provides context and reasoning
-- Focus on why the change was necessary
-- Help future developers understand the decision
-- Write as if describing the codebase NOW, not its history or future
-
----
 
 ---
 
@@ -324,11 +68,206 @@ empty grep:
 curl -s https://api.shovels.ai/spec/v2/openapi.production.yaml | grep -n "field_name"
 ```
 
+---
+
+## Local Preview and Validation
+
+This repository has **no unit tests**. Do not look for a test suite, and do not stop to ask
+which tests to run — there are none. Validation is the two commands below.
+
+```bash
+# Local preview at http://localhost:3000
+mint dev
+
+# On a custom port
+mint dev --port 3333
+
+# Link validation
+mint broken-links
+```
+
+**Before committing, run `mint broken-links`.**
+
+Interpreting its output requires care:
+
+- Links under `/api-reference/*` are reported as broken but are **false positives**. Those pages
+  are generated remotely, so the validator cannot resolve them. Ignore them.
+- The baseline on a clean `main` is **66 flagged links**, of which exactly one is genuine:
+  `/foundations-permit-availability` (tracked separately).
+- What matters is **the count relative to the baseline, not zero.** If your branch reports more
+  than `main` does, you introduced a broken link. Run the command on `main` to compare rather
+  than assuming.
+
+**Verify rendered output, not just the build.** A page can build cleanly, return HTTP 200, and
+still be wrong — navigation in particular. Changes to `docs.json` navigation, Mintlify
+components, or anything under the API Reference tab must be checked in a running `mint dev`
+preview by actually looking at the page. Programmatic checks alone are not sufficient evidence.
+
+---
+
+## Content Standards
+
+**Scope discipline:**
+- Make the SMALLEST reasonable change that achieves the outcome
+- YOU MUST NEVER make content changes unrelated to your current task. If you notice something
+  that should be fixed but is unrelated, raise it rather than fixing it silently
+- YOU MUST MATCH the voice, structure, and formatting of surrounding pages. Consistency within
+  the docs trumps external style guides
+- YOU MUST NOT change whitespace that does not affect rendered output
+
+**Atomic changes:**
+- Break work into small, self-contained steps, each wrapped in its own commit
+- Keep git history bisectable
+
+**Writing:**
+- Every page needs frontmatter with `title`; add `description` for anything a reader may land on
+  from search
+- Use Mintlify components (`<Info>`, `<Note>`, `<Warning>`, `<Tabs>`, `<CodeGroup>`, `<Frame>`,
+  `<Update>`) rather than hand-rolled markdown equivalents
+- Write evergreen content. NEVER reference what a page used to say, or describe something as
+  "new", "improved", or "enhanced" — what is new today is stale in six months
+- Prefer explaining WHY over restating WHAT the interface already shows
+
+**File naming:**
+- kebab-case for MDX files, e.g. `shovels-api-introduction.mdx`
+- Prefix by category where it helps: `data-dictionary-*`, `tutorial-*`, `shovels-online-*`,
+  `shovels-api-*`
+
+**Links:**
+- Internal links are root-relative and omit the extension, e.g. `/docs/shovels-faq`
+- Contact links use `support@shovels.ai` and `sales@shovels.ai` — note the `.ai` domain
+
+---
+
+## Version Control & Git
+
+**Commit frequency:**
+- YOU MUST commit frequently throughout the process, even if the high-level task is not done
+
+**Pre-commit hooks:**
+- NEVER SKIP OR EVADE OR DISABLE A PRE-COMMIT HOOK
+
+**Staging changes:**
+- NEVER use `git add -A` unless you've just run `git status` — you don't want to commit stray
+  scratch files
+
+**Temporal context:**
+- YOU MUST NEVER leave temporal context in a commit message (like "recently refactored",
+  "moved"). The body describes the repository as it is
+- If you name something "new" or "enhanced" or "improved", you've probably made a mistake and
+  MUST STOP and ask
+
+---
+
+## Commit Message Guidelines
+
+Follow these rules for great Git commit messages:
+
+### Format Rules
+
+1. **Separate subject from body** with a blank line
+2. **Limit subject line to 50 characters** - forces concise, thoughtful descriptions
+3. **Capitalize the subject line** - begin with capital letter
+4. **No period at end** of subject line - saves space
+5. **Use imperative mood** in subject line - write as command ("Add feature" not "Added feature")
+6. **Wrap body at 72 characters** - ensures readability across tools
+7. **Explain what and why, not how** - focus on reasons for change and problem solved
+
+### Content Rules
+
+** NEVER include:**
+- Process tracking: "Step 5", "Phase 2", "Task ABC-123"
+- Ticket IDs: ENG-123, JIRA-456, issue #789, Linear references
+- Metrics: "200 LOC", "95% coverage", "within target"
+- Temporal context (past): "recently refactored", "previously moved", "used to be"
+- Temporal context (future): "will fix later", "next step", "TODO", "this prepares for"
+- Self-praise: "successfully", "perfect", "excellent"
+- Irrelevant details: test counts, files changed, tool promotions
+- Verbose bloat: Restating subject line, over-explaining obvious changes
+
+** ALWAYS include:**
+- Technical rationale (WHY architecturally)
+- Timeless context (readable in 6 months without project docs)
+- Tradeoffs (if accepting debt, explain)
+
+### Examples
+
+**Bad - Temporal context (future):**
+```
+Add an About page to the API Reference
+
+Explains that the reference is generated from the spec.
+
+Next step: add the same notice to the README.
+```
+**BAD** - "Next step" refers to future work - not evergreen
+
+**Bad - Temporal context (past):**
+```
+Move the pagination guidance into the FAQ
+
+This used to live in the API introduction but was recently
+split out when we reorganized the troubleshooting pages.
+```
+**BAD** - "used to live", "recently" - refers to history
+
+**Bad - Process tracking:**
+```
+Update knowledge base articles (Step 2, Phase 4.1 complete)
+
+Files changed: 12, links checked: 66
+```
+**BAD** - "Step 2", "Phase 4.1", metrics
+
+**Bad - Ticket references and verbose bloat:**
+```
+Correct the contact addresses in the FAQ
+
+Replace the support and sales mailto links with the correct
+domain.
+
+This follows MAR-340 Goal #2 to clean up outbound links across
+the documentation. All four links in the FAQ now point at the
+right place instead of the old ones.
+```
+**BAD** - "MAR-340" ticket reference, verbose restatement of obvious
+
+**Good - Evergreen, explains WHY:**
+```
+Publish an About page for the API Reference
+
+The API Reference tab is generated from the OpenAPI
+specification, but nothing on the rendered site said so.
+Readers had no route for reporting an endpoint that
+disagreed with the live API.
+```
+**GOOD** - Timeless context, explains the reason for the page
+
+**Good - Concise context:**
+```
+Fix contact email domain in the FAQ
+
+Four support and sales links pointed at shovels.com, which
+does not resolve. Readers hitting those links got nothing.
+```
+**GOOD** - Clear WHY (dead links), no ticket refs, no bloat
+
+**Key principles:**
+- Subject line communicates the change clearly
+- Body provides context and reasoning
+- Focus on why the change was necessary
+- Help future developers understand the decision
+- Write as if describing the codebase NOW, not its history or future
+
+---
+
 ## Repository Integration
 
 **Project documentation:**
-- YOU MUST read README.md for project overview
-- YOU MUST read pyproject.toml for available `uv` commands for this project
+- YOU MUST read `README.md` for the project overview
+- `docs.json` is the Mintlify configuration: navigation, theming, redirects, and the OpenAPI
+  source. There is no `package.json` or `pyproject.toml` in this repo — Mintlify is installed
+  globally via `npm i -g mintlify`
 
 **Linear Issue Integration:**
 - ALWAYS use Linear MCP to read Linear issues and get correct git branch names

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,48 @@ code across route packages following three-level sharing convention.
 
 ---
 
+---
+
+## Generated Content: The API Reference Is Not In This Repo
+
+**Before searching this repository for API documentation, read this.**
+
+The entire **API Reference** tab of the docs site is generated at build time from the Shovels
+OpenAPI specification. It is configured in `docs.json`:
+
+```json
+"openapi": {
+  "source": "https://api.shovels.ai/spec/v2/openapi.production.yaml",
+  "directory": "api-reference"
+}
+```
+
+**No file in this repository backs those pages.** A grep for an endpoint path, a field name, a
+parameter default, or a response schema will return zero results even when the published docs
+plainly show it.
+
+**An empty grep result here does not mean the content is undocumented.** It usually means the
+content is in the spec.
+
+### What this means for a task
+
+- Asked to change an endpoint's parameters, defaults, types, descriptions, or response schema?
+  That is a **spec change on the API side**, not a change to this repo. Say so and stop rather
+  than editing prose pages that merely mention the field.
+- Asked to change a quickstart, tutorial, data dictionary, FAQ, troubleshooting, or release note?
+  That is hand-written MDX under `docs/` or `release-notes/` and is editable here.
+- A task may be **partly** each. Fix the hand-written pages, and report the spec portion as
+  out-of-scope for this repo instead of silently leaving it undone.
+
+### Verify before concluding
+
+To confirm whether something is spec-owned, fetch the spec directly rather than inferring from an
+empty grep:
+
+```bash
+curl -s https://api.shovels.ai/spec/v2/openapi.production.yaml | grep -n "field_name"
+```
+
 ## Repository Integration
 
 **Project documentation:**

--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@ Source for public-facing Shovels Product and API documentation
 
 This is the Shovels documentation repository, built with Mintlify. It contains public-facing product and API documentation for Shovels, a platform that provides building permit and contractor data through both an online interface and REST API.
 
+## Generated vs. hand-written content
+
+**Not everything on the docs site lives in this repository.**
+
+The entire **API Reference** tab is generated at build time from the Shovels OpenAPI
+specification, which is served by the API and configured in `docs.json`:
+
+```json
+"openapi": {
+  "source": "https://api.shovels.ai/spec/v2/openapi.production.yaml",
+  "directory": "api-reference"
+}
+```
+
+No file in this repo backs those pages. Searching for an endpoint, a field name, a parameter
+default, or a response schema will return nothing here even when the rendered docs clearly show
+it. That is expected, not a sign the content is undocumented.
+
+| Where it renders | Source | Change it by |
+|---|---|---|
+| `docs.shovels.ai/api-reference/*` | OpenAPI spec, fetched at build time | Editing the spec — an API-side change, not a docs change |
+| Everything else (`docs/`, `release-notes/`) | MDX files in this repo | Editing the file and opening a PR |
+
+**Before filing or starting a docs ticket**, check which side of that line it falls on. Requests
+to correct an endpoint's parameters, defaults, types, descriptions, or response schema are spec
+changes and belong with the API team. Only the hand-written prose pages are fixable here.
+
+`docs/api-reference-about.mdx` is the reader-facing version of this explanation and is published
+as the first page of the API Reference tab.
+
 ## Development Commands
 
 ### Local Development
@@ -36,7 +66,7 @@ npm i -g mintlify@latest
 ## Architecture
 
 ### Project Structure
-- `mint.json` - Main Mintlify configuration file defining site structure, navigation, theming, and API integration
+- `docs.json` - Main Mintlify configuration file defining site structure, navigation, theming, and API integration
 - `docs/` - Contains all MDX documentation files organized by topic:
   - Introduction and quickstart guides
   - Tutorials for both Shovels Online and API
@@ -45,10 +75,9 @@ npm i -g mintlify@latest
   - Foundation concepts
 - `assets/` - Images, logos, and static assets
 - `release-notes/` - Version release documentation
-- Root-level MDX files: `development.mdx`, `quickstart.mdx`
 
 ### Key Configuration Elements
-- **API Integration**: Configured to pull OpenAPI spec from `https://api.shovels.ai/v2/openapi.production.yaml`
+- **API Integration**: Configured to pull the OpenAPI spec from `https://api.shovels.ai/spec/v2/openapi.production.yaml` (see [Generated vs. hand-written content](#generated-vs-hand-written-content))
 - **Theming**: Custom Shovels branding with green primary colors (#01654D) and Poppins font
 - **Navigation**: Organized into logical groups (Tutorials, Troubleshooting, Platform Reference, etc.)
 - **External Links**: Integrated with data dictionary spreadsheet, coverage dashboard, Discord community
@@ -99,7 +128,7 @@ npm i -g mintlify@latest
 
 ### Adding New Releases
 - New releases are added at the top of the file (newest first)
-- Navigation is automatically handled by the single file reference in `mint.json`
+- Navigation is automatically handled by the single file reference in `docs.json`
 - Use consistent emoji prefixes and section naming
 - Include specific numbers and statistics when available (permit counts, new jurisdictions, etc.)
 

--- a/docs.json
+++ b/docs.json
@@ -175,10 +175,21 @@
       },
       {
         "tab": "API Reference",
-        "openapi": {
-          "source": "https://api.shovels.ai/spec/v2/openapi.production.yaml",
-          "directory": "api-reference"
-        }
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "docs/api-reference-about"
+            ]
+          },
+          {
+            "group": "Endpoints",
+            "openapi": {
+              "source": "https://api.shovels.ai/spec/v2/openapi.production.yaml",
+              "directory": "api-reference"
+            }
+          }
+        ]
       },
       {
         "tab": "Release Notes",

--- a/docs/api-reference-about.mdx
+++ b/docs/api-reference-about.mdx
@@ -1,0 +1,32 @@
+---
+title: "About the API Reference"
+description: "How the Shovels API Reference is generated, what it covers, and where to report an error."
+---
+
+Every page in the **API Reference** tab is generated directly from the Shovels OpenAPI
+specification — the same specification the live API is built against. Endpoints, parameters,
+field names, defaults, and response schemas all come from that one source, so the reference
+cannot drift out of step with the API itself.
+
+## What this means for you
+
+- **The reference is always current.** When an endpoint gains a parameter or a default changes,
+  the documentation updates with it. There is no separate step where someone has to remember to
+  write it down.
+- **Examples run against the real API.** The interactive playground on each endpoint page calls
+  `https://api.shovels.ai/v2` using your own API key.
+- **Prose guides are written by hand.** Everything outside the API Reference tab — quickstarts,
+  tutorials, the data dictionaries, troubleshooting — is written and maintained by our team.
+  Those pages explain *how* and *why*; the API Reference documents *what*.
+
+## Found an error?
+
+If an endpoint page shows a wrong default, a stale field, or a response that doesn't match what
+the API actually returns, email [support@shovels.ai](mailto:support@shovels.ai) with the endpoint
+and what you observed.
+
+<Info>
+  Corrections to the API Reference are made in the OpenAPI specification rather than on the
+  documentation site, so these fixes ship with the API. Please include the endpoint path and
+  method — it's the fastest way for us to trace the field back to the specification.
+</Info>

--- a/docs/shovels-api-introduction.mdx
+++ b/docs/shovels-api-introduction.mdx
@@ -5,6 +5,11 @@ description: "Comprehensive guide to the Shovels REST API, including authenticat
 
 The Shovels REST API makes it easy for technology developers in the property, climate, and construction industries to access detailed information about building permits, contractors and construction activity. Our API is designed to be intuitive and fast. We look forward to seeing what you build with it: [let us know](https://docs.google.com/forms/d/e/1FAIpQLSfs5Z6NZyPdnRpL96bMduH95OhfFZgLz9Hkc0-Y7pukUxSLxQ/viewform) and we'll check it out!
 
+<Info>
+  The [API Reference](/docs/api-reference-about) is generated directly from our OpenAPI
+  specification, so it always matches the live API.
+</Info>
+
 ## Key Features
 
 The API offers access to three primary objects: **Permits**, **Contractors**, and **Properties**.


### PR DESCRIPTION
Closes [MAR-332](https://linear.app/shovels/issue/MAR-332/flag-in-shovels-docs-which-pages-are-generated-from-the-api-spec)

## Why

Nothing in this repo signalled that the API Reference is not editable content. Everything under `api-reference/` is generated at build time from `https://api.shovels.ai/spec/v2/openapi.production.yaml`, so a grep for a field name or a parameter default returns nothing even when the rendered docs plainly show it.

Two tickets in a row were filed against this repo for content it does not contain — [MAR-327](https://linear.app/shovels/issue/MAR-327/fix-the-openapi-spec-drop-is-trial-correct-the-size-default) (`is_trial`) and [MAR-328](https://linear.app/shovels/issue/MAR-328/document-default-size-10-for-cursor-pagination) (the `size` default). Both were spec changes. Both had to be re-scoped and reassigned after work started. Both were written by people reasonably assuming the API reference lives where the rest of the docs live.

## What changed

**Reader-facing** — a new `docs/api-reference-about.mdx`, published as the first page of the API Reference tab.

It is framed as a trust signal rather than a disclaimer: the reference is generated from the spec, *therefore* it cannot drift from the live API. Then the routing part — errors go to support@shovels.ai, with a note that corrections are made in the spec so they ship with the API. Also linked from the API introduction page.

**Contributor-facing** — a "Generated vs. hand-written content" section in `README.md` with a table drawing the line, and a longer version in `CLAUDE.md`.

`CLAUDE.md` gets the fuller treatment because agents grep before they read, and an empty result is the exact moment the wrong conclusion gets drawn. It leads with *"an empty grep result does not mean the content is undocumented"* and gives a `curl | grep` against the spec to check.

## The navigation change is not cosmetic

`docs.json` moves the API Reference tab from a bare `openapi` directive to two groups (`Getting Started` / `Endpoints`).

My first attempt listed the page under `pages` alongside the existing `openapi` block — which is what Mintlify's own docs show. It built fine and served 200, but Mintlify rendered them as **two separate navigation contexts**. The About page's sidebar dropped all 34 endpoints, and endpoint pages did not show the About link. A cul-de-sac in both directions.

Every programmatic check passed; this was only visible in the rendered sidebar. The group structure fixes it, verified in both directions.

**Side effect worth a look:** grouping means the 13 endpoint tag categories are now collapsible and collapse by default, except the active one. Previously all were expanded. I think it reads better at 34 endpoints, but nobody asked for it — happy to flatten it back.

## Also fixed

Three stale things in the lines being rewritten anyway:

- The documented spec URL was missing `/spec/` and **returns 404**. The one place the README pointed at the spec, it pointed at nothing.
- Two references to `mint.json`, which the repo replaced with `docs.json`.
- A bullet listing root-level `development.mdx` and `quickstart.mdx`. Neither exists.

## Verification

- All 34 generated endpoint routes intact (counted before and after).
- `/docs/api-reference-about`, `/docs/shovels-api-introduction`, and sampled endpoint pages all serve 200.
- Navigation confirmed working in both directions in a local `mint dev` preview.
- `mint broken-links` identical before and after: 66 flagged lines on a clean `main` and 66 on this branch. **No new broken links.** For context, 65 of those are `/api-reference/*` false positives the validator cannot resolve because the pages are generated remotely; the one genuine pre-existing broken link is `/foundations-permit-availability`.

## Deliberately not done

Per-endpoint notices would need `x-mint: content` on every operation in the OpenAPI spec — an API-side change. Out of scope here; the About page plus the README and CLAUDE.md guidance is the cheap 80%.
