### PR TITLE
Rewrite CLAUDE.md to describe the docs repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
-# Project Engineering Standards
+# Documentation Repository Standards
 
-Project-wide coding standards and conventions for this codebase.
+Standards and conventions for `shovels-docs`, the public-facing Shovels documentation site.
+
+This is a **Mintlify documentation site**. It contains MDX content, `docs.json` configuration,
+and static assets. There is no application code here: no Python, no test suite, no build
+pipeline beyond Mintlify itself.
 
 ---
 
@@ -21,266 +25,6 @@ We're colleagues working together - no formal hierarchy.
 - You search your journal when you're trying to remember or figure stuff out
 
 **Rule #1**: If you want exception to ANY rule, YOU MUST STOP and get explicit permission from the user first. BREAKING THE LETTER OR SPIRIT OF THE RULES IS FAILURE.
-
----
-
-## Software Design Philosophy
-
-**YAGNI**: The best code is no code. Don't add features we don't need right now.
-
-**Design principles:**
-- Design for extensibility and flexibility
-- Prefer simple, clean, maintainable solutions over clever or complex ones, even if the latter are more concise or performant
-- Readability and maintainability are primary concerns
-- Good naming is very important. Name functions, variables, classes, etc so that the full breadth of their utility is obvious
-- Reusable, generic things should have reusable generic names
-
----
-
-## Code Implementation Standards
-
-**Atomic changes:**
-- YOU MUST ALWAYS break a plan into small atomic and fully functional steps
-- Each step should encapsulate the smallest reasonable change to the code
-- Each step should include unit tests. All tests should pass
-- Each such step should be wrapped into a commit
-- YOU MUST ALWAYS adhere to clean git history principle: we want to be able to track atomic changes and be able to git bisect to find elusive bugs
-- YOU MUST ALWAYS perform prefactory refactoring (preparatory refactoring) if you're working on a complex task that requires this in order to follow our rules
-
-**Code quality:**
-- YOU MUST make the SMALLEST reasonable changes to achieve the desired outcome
-- YOU MUST WORK HARD to reduce code duplication, even if the refactoring takes extra effort
-- YOU MUST MATCH the style and formatting of surrounding code, even if it differs from standard style guides. Consistency within a file trumps external standards
-- YOU MUST NOT change whitespace that does not affect execution or output. Otherwise, use a formatting tool
-- Follow Python 3.11+ standards with Google's PEP8 (100 char line limit)
-
-**Test requirements:**
-- YOU MUST run and verify ALL specified tests pass before committing
-- If tests fail, timeout, or cannot run: YOU MUST STOP immediately and consult user
-- NEVER proceed with "tests will be verified later" or "tests probably work"
-- Test evidence: Run command cleanly (success = no error field populated in tool response)
-- ❌ NEVER use `;` followed by `echo "Exit code: $?"` - triggers approval prompts repeatedly
-- ✅ The Bash tool automatically shows command success/failure - no manual exit code checking needed
-- If you lack observability into why tests fail (no server logs, etc): YOU MUST STOP and consult user
-- DO NOT investigate test failures outside the scope of your task - consult user first
-
-**What to NEVER do:**
-- YOU MUST NEVER make code changes unrelated to your current task. If you notice something that should be fixed but is unrelated, document it in your journal rather than fixing it immediately
-- YOU MUST NEVER throw away or rewrite implementations without EXPLICIT permission. If you're considering this, YOU MUST STOP and ask first
-- YOU MUST get user's explicit approval before implementing ANY backward compatibility changes
-- NEVER implement a mock mode for testing or for any purpose. We always use real data and real APIs, never mock implementations
-- NEVER name things as "improved" or "new" or "enhanced", etc. Code naming should be evergreen. What is new someday will be "old" someday
-
-**Comments and documentation:**
-- YOU MUST explain WHY (complex business logic) over WHAT (code should be simple to speak for itself) in comments
-- YOU MUST NEVER add comments about what used to be there or how something has changed
-- YOU MUST NEVER refer to temporal context in comments (like "recently refactored" "moved") or code. Comments should be evergreen and describe the code as it is
-
----
-
-## Unit Testing Principles
-
-When reviewing or writing unit tests:
-
-**YOU MUST ALWAYS:**
-- Inject all dependencies via constructor parameters, method parameters, or test fixtures
-- Maintain clear separation between test and production code
-- Focus on observable results, state changes, and return values
-- Test public interfaces and contracts, not internal implementation details
-- Verify external interactions through their results, not method calls
-- Write tests that survive refactoring when behavior remains unchanged
-- Test all execution paths and conditional branches
-- Use clear descriptive names: `test_method_scenario` or `test_behavior_when_condition`
-- Use one logical assertion per test case
-- Follow: verbose is better than complex - tests can repeat themselves for readability
-- One test case per input example - each specific input-output pair gets its own test
-- Test failures should make it immediately clear why they failed
-
-**YOU MUST NEVER:**
-- Use `unittest.mock.patch`, monkeypatch, or global variable modifications (except in CLI/integration tests where mocking AWS/external services is necessary)
-- Implement complex logic in tests - avoid loops, conditionals, or "tests for tests"
-- Test internal method call sequences using assert_called_with or similar patterns
-- Miss edge cases or error scenario coverage
-- Test with unclear purpose or multiple unrelated assertions
-- Hard-code dependencies in test setup
-
-**Private method testing guidance:**
-- Prefer testing through public interfaces when practical
-- Test private methods directly when:
-  1. They have complex logic with many edge cases (especially security-critical functions like SQL escaping)
-  2. Failure would be hard to diagnose through public interface alone
-  3. The private method is a pure utility function
-- If a private method needs extensive testing, consider extracting to a public utility module (e.g., `api/app/lib/sql/escaping.py`)
-
----
-
-## Shared Code Organization
-
-Follow these conventions for organizing shared code:
-
-### Three Levels of Sharing
-
-1. **Repo-level libraries** (`api/app/lib/`)
-   - Used by 3+ packages across different domains
-   - Examples: `lib/pagination/`, `lib/geo/`, `lib/csv/`
-   - Pure utilities with no domain-specific coupling
-
-2. **Package-level helpers** (`package/helpers.py`)
-   - Used by multiple modules within one package
-   - Examples: `contractors/helpers.py`, `geo_metrics/helpers.py`
-   - Domain-specific utilities (query builders, formatters)
-
-3. **Inline utilities**
-   - Used by single module only
-   - Keep in the module file itself
-   - Extract to helpers.py if ≥3 functions or >50 LOC
-
-### Decision Criteria
-
-**Move to `lib/` when:**
-- Function is pure utility (no domain coupling)
-- Used across 3+ different packages
-- Consolidates duplication (e.g., geo ID formatting used by all geo_* packages)
-
-**Keep in `package/helpers.py` when:**
-- Domain-specific (e.g., contractor-specific query logic)
-- Used by 2+ modules in same package only
-
-**Keep inline when:**
-- Single module usage
-- < 50 LOC of shared code
-
----
-
-## Python Execution
-
-**ALWAYS use absolute imports** in this project.
-**ALWAYS run `uv run`. NEVER execute `python` directly.**
-
-`uv` automatically adds project root to `PYTHONPATH`.
-
----
-
-## Version Control & Git
-
-**Commit frequency:**
-- YOU MUST commit frequently throughout the development process, even if your high-level tasks are not yet done
-
-**Pre-commit hooks:**
-- NEVER SKIP OR EVADE OR DISABLE A PRE-COMMIT HOOK
-
-**Staging changes:**
-- NEVER use `git add -A` unless you've just done a `git status` - You don't want to add random test files to the repo
-
-**Temporal context:**
-- YOU MUST NEVER leave temporal context in git description (like "recently refactored" "moved") or code
-- Body should be evergreen and describe the code as it is
-- If you name something "new" or "enhanced" or "improved", you've probably made a mistake and MUST STOP and ask me what to do
-
----
-
-## Commit Message Guidelines
-
-Follow these rules for great Git commit messages:
-
-### Format Rules
-
-1. **Separate subject from body** with a blank line
-2. **Limit subject line to 50 characters** - forces concise, thoughtful descriptions
-3. **Capitalize the subject line** - begin with capital letter
-4. **No period at end** of subject line - saves space
-5. **Use imperative mood** in subject line - write as command ("Add feature" not "Added feature")
-6. **Wrap body at 72 characters** - ensures readability across tools
-7. **Explain what and why, not how** - focus on reasons for change and problem solved
-
-### Content Rules
-
-** NEVER include:**
-- Process tracking: "Step 5", "Phase 2", "Task ABC-123"
-- Ticket IDs: ENG-123, JIRA-456, issue #789, Linear references
-- Metrics: "200 LOC", "95% coverage", "within target"
-- Temporal context (past): "recently refactored", "previously moved", "used to be"
-- Temporal context (future): "will fix later", "next step", "TODO", "this prepares for"
-- Self-praise: "successfully", "perfect", "excellent"
-- Irrelevant details: test counts, files changed, tool promotions
-- Verbose bloat: Restating subject line, over-explaining obvious changes
-
-** ALWAYS include:**
-- Technical rationale (WHY architecturally)
-- Timeless context (readable in 6 months without project docs)
-- Tradeoffs (if accepting debt, explain)
-
-### Examples
-
-**Bad - Temporal context (future):**
-```
-Create lib/geo/formatting module
-
-Extract formatting utilities to shared library.
-
-Next step: Update route modules to import from lib/geo.
-```
-**BAD** - "Next step" refers to future work - not evergreen
-
-**Bad - Temporal context (past):**
-```
-Move formatting functions to lib/geo
-
-These were previously in geo_search/addresses.py but
-recently refactored to be shared across modules.
-```
-**BAD** - "previously", "recently refactored" - refers to history
-
-**Bad - Process tracking:**
-```
-Extract addresses endpoint (Step 2, Phase 4.1 complete)
-
-Files changed: 3, Tests: 15 passing
-```
-**BAD** - "Step 2", "Phase 4.1", metrics
-
-**Bad - Ticket references and verbose bloat:**
-```
-Update geo routes to import from lib/geo
-
-Replace local function definitions with imports from centralized
-api.app.lib.geo.formatting module.
-
-This follows ENG-613 Goal #3 to consolidate duplicated code into
-well-defined libraries. All route modules now use shared geo
-utilities instead of maintaining local copies.
-```
-**BAD** - "ENG-613" ticket reference, verbose restatement of obvious
-
-**Good - Evergreen, explains WHY:**
-```
-Extract addresses endpoint to dedicated module
-
-Move address search logic to addresses.py following Single
-Responsibility Principle. Shared helpers remain in legacy
-file temporarily to support remaining endpoints during
-incremental migration.
-```
-**GOOD** - Timeless context, explains architectural reasoning
-
-**Good - Concise architectural context:**
-```
-Update geo routes to import from lib/geo
-
-Replace local function definitions with imports from centralized
-api.app.lib.geo.formatting module. Consolidates duplicate utility
-code across route packages following three-level sharing convention.
-```
-**GOOD** - Clear WHY (consolidation), no ticket refs, no bloat
-
-**Key principles:**
-- Subject line communicates the change clearly
-- Body provides context and reasoning
-- Focus on why the change was necessary
-- Help future developers understand the decision
-- Write as if describing the codebase NOW, not its history or future
-
----
 
 ---
 
@@ -324,11 +68,206 @@ empty grep:
 curl -s https://api.shovels.ai/spec/v2/openapi.production.yaml | grep -n "field_name"
 ```
 
+---
+
+## Local Preview and Validation
+
+This repository has **no unit tests**. Do not look for a test suite, and do not stop to ask
+which tests to run — there are none. Validation is the two commands below.
+
+```bash
+# Local preview at http://localhost:3000
+mint dev
+
+# On a custom port
+mint dev --port 3333
+
+# Link validation
+mint broken-links
+```
+
+**Before committing, run `mint broken-links`.**
+
+Interpreting its output requires care:
+
+- Links under `/api-reference/*` are reported as broken but are **false positives**. Those pages
+  are generated remotely, so the validator cannot resolve them. Ignore them.
+- The baseline on a clean `main` is **66 flagged links**, of which exactly one is genuine:
+  `/foundations-permit-availability` (tracked separately).
+- What matters is **the count relative to the baseline, not zero.** If your branch reports more
+  than `main` does, you introduced a broken link. Run the command on `main` to compare rather
+  than assuming.
+
+**Verify rendered output, not just the build.** A page can build cleanly, return HTTP 200, and
+still be wrong — navigation in particular. Changes to `docs.json` navigation, Mintlify
+components, or anything under the API Reference tab must be checked in a running `mint dev`
+preview by actually looking at the page. Programmatic checks alone are not sufficient evidence.
+
+---
+
+## Content Standards
+
+**Scope discipline:**
+- Make the SMALLEST reasonable change that achieves the outcome
+- YOU MUST NEVER make content changes unrelated to your current task. If you notice something
+  that should be fixed but is unrelated, raise it rather than fixing it silently
+- YOU MUST MATCH the voice, structure, and formatting of surrounding pages. Consistency within
+  the docs trumps external style guides
+- YOU MUST NOT change whitespace that does not affect rendered output
+
+**Atomic changes:**
+- Break work into small, self-contained steps, each wrapped in its own commit
+- Keep git history bisectable
+
+**Writing:**
+- Every page needs frontmatter with `title`; add `description` for anything a reader may land on
+  from search
+- Use Mintlify components (`<Info>`, `<Note>`, `<Warning>`, `<Tabs>`, `<CodeGroup>`, `<Frame>`,
+  `<Update>`) rather than hand-rolled markdown equivalents
+- Write evergreen content. NEVER reference what a page used to say, or describe something as
+  "new", "improved", or "enhanced" — what is new today is stale in six months
+- Prefer explaining WHY over restating WHAT the interface already shows
+
+**File naming:**
+- kebab-case for MDX files, e.g. `shovels-api-introduction.mdx`
+- Prefix by category where it helps: `data-dictionary-*`, `tutorial-*`, `shovels-online-*`,
+  `shovels-api-*`
+
+**Links:**
+- Internal links are root-relative and omit the extension, e.g. `/docs/shovels-faq`
+- Contact links use `support@shovels.ai` and `sales@shovels.ai` — note the `.ai` domain
+
+---
+
+## Version Control & Git
+
+**Commit frequency:**
+- YOU MUST commit frequently throughout the process, even if the high-level task is not done
+
+**Pre-commit hooks:**
+- NEVER SKIP OR EVADE OR DISABLE A PRE-COMMIT HOOK
+
+**Staging changes:**
+- NEVER use `git add -A` unless you've just run `git status` — you don't want to commit stray
+  scratch files
+
+**Temporal context:**
+- YOU MUST NEVER leave temporal context in a commit message (like "recently refactored",
+  "moved"). The body describes the repository as it is
+- If you name something "new" or "enhanced" or "improved", you've probably made a mistake and
+  MUST STOP and ask
+
+---
+
+## Commit Message Guidelines
+
+Follow these rules for great Git commit messages:
+
+### Format Rules
+
+1. **Separate subject from body** with a blank line
+2. **Limit subject line to 50 characters** - forces concise, thoughtful descriptions
+3. **Capitalize the subject line** - begin with capital letter
+4. **No period at end** of subject line - saves space
+5. **Use imperative mood** in subject line - write as command ("Add feature" not "Added feature")
+6. **Wrap body at 72 characters** - ensures readability across tools
+7. **Explain what and why, not how** - focus on reasons for change and problem solved
+
+### Content Rules
+
+** NEVER include:**
+- Process tracking: "Step 5", "Phase 2", "Task ABC-123"
+- Ticket IDs: ENG-123, JIRA-456, issue #789, Linear references
+- Metrics: "200 LOC", "95% coverage", "within target"
+- Temporal context (past): "recently refactored", "previously moved", "used to be"
+- Temporal context (future): "will fix later", "next step", "TODO", "this prepares for"
+- Self-praise: "successfully", "perfect", "excellent"
+- Irrelevant details: test counts, files changed, tool promotions
+- Verbose bloat: Restating subject line, over-explaining obvious changes
+
+** ALWAYS include:**
+- Technical rationale (WHY architecturally)
+- Timeless context (readable in 6 months without project docs)
+- Tradeoffs (if accepting debt, explain)
+
+### Examples
+
+**Bad - Temporal context (future):**
+```
+Add an About page to the API Reference
+
+Explains that the reference is generated from the spec.
+
+Next step: add the same notice to the README.
+```
+**BAD** - "Next step" refers to future work - not evergreen
+
+**Bad - Temporal context (past):**
+```
+Move the pagination guidance into the FAQ
+
+This used to live in the API introduction but was recently
+split out when we reorganized the troubleshooting pages.
+```
+**BAD** - "used to live", "recently" - refers to history
+
+**Bad - Process tracking:**
+```
+Update knowledge base articles (Step 2, Phase 4.1 complete)
+
+Files changed: 12, links checked: 66
+```
+**BAD** - "Step 2", "Phase 4.1", metrics
+
+**Bad - Ticket references and verbose bloat:**
+```
+Correct the contact addresses in the FAQ
+
+Replace the support and sales mailto links with the correct
+domain.
+
+This follows MAR-340 Goal #2 to clean up outbound links across
+the documentation. All four links in the FAQ now point at the
+right place instead of the old ones.
+```
+**BAD** - "MAR-340" ticket reference, verbose restatement of obvious
+
+**Good - Evergreen, explains WHY:**
+```
+Publish an About page for the API Reference
+
+The API Reference tab is generated from the OpenAPI
+specification, but nothing on the rendered site said so.
+Readers had no route for reporting an endpoint that
+disagreed with the live API.
+```
+**GOOD** - Timeless context, explains the reason for the page
+
+**Good - Concise context:**
+```
+Fix contact email domain in the FAQ
+
+Four support and sales links pointed at shovels.com, which
+does not resolve. Readers hitting those links got nothing.
+```
+**GOOD** - Clear WHY (dead links), no ticket refs, no bloat
+
+**Key principles:**
+- Subject line communicates the change clearly
+- Body provides context and reasoning
+- Focus on why the change was necessary
+- Help future developers understand the decision
+- Write as if describing the codebase NOW, not its history or future
+
+---
+
 ## Repository Integration
 
 **Project documentation:**
-- YOU MUST read README.md for project overview
-- YOU MUST read pyproject.toml for available `uv` commands for this project
+- YOU MUST read `README.md` for the project overview
+- `docs.json` is the Mintlify configuration: navigation, theming, redirects, and the OpenAPI
+  source. There is no `package.json` or `pyproject.toml` in this repo — Mintlify is installed
+  globally via `npm i -g mintlify`
 
 **Linear Issue Integration:**
 - ALWAYS use Linear MCP to read Linear issues and get correct git branch names


### PR DESCRIPTION
Closes [MAR-335](https://linear.app/shovels/issue/MAR-335/rewrite-claudemd-to-describe-the-docs-repo)

> **Stacked on #67.** Base is the MAR-332 branch, so the diff below shows only the `CLAUDE.md` rewrite. GitHub will retarget this to `main` automatically once #67 merges. Please review #67 first.

## Why

`CLAUDE.md` described a Python service. This repo is a Mintlify documentation site with **zero Python files, no `pyproject.toml`, and no test suite.**

Five instructions could not be followed at all:

| Line | Instruction | Reality |
|---|---|---|
| 45 | "Each step should include unit tests. All tests should pass" | No test suite exists |
| 58 | "YOU MUST run and verify ALL specified tests pass before committing" | Nothing to run |
| 59 | "If tests fail, timeout, or cannot run: YOU MUST STOP immediately and consult user" | They can never run |
| 158 | "ALWAYS run `uv run`. NEVER execute `python` directly" | No Python in the repo |
| 289 | "YOU MUST read pyproject.toml for available `uv` commands" | File does not exist |

Plus ~35 lines on `unittest.mock` and fixtures, and a "Shared Code Organization" section routing code into `api/app/lib/`.

### The part that actually costs us something

Two failure modes, pulling in opposite directions.

A **literal** agent obeys line 59: it cannot run tests, so it stops and asks what to do — before every commit, on every task, forever.

A **non-literal** agent does what happened while completing MAR-332. It ran `python3` directly to patch JSON and MDX, and committed twice without running tests. Both were the right calls for a docs repo. But it means the agent silently concluded the file doesn't mean what it says.

**The second mode is the expensive one.** Once `CLAUDE.md` reads as aspirational, every instruction inherits that discount — including the load-bearing ones.

That is a direct cost to #67. The section it adds tells agents that `api-reference/` is generated from the OpenAPI spec and is not editable here. It exists precisely to stop the mis-scoped tickets that [MAR-327](https://linear.app/shovels/issue/MAR-327/fix-the-openapi-spec-drop-is-trial-correct-the-size-default) and [MAR-328](https://linear.app/shovels/issue/MAR-328/document-default-size-10-for-cursor-pagination) became. Its entire value depends on being believed — and it currently sits in a file that has trained agents not to believe it.

## What changed

**Kept as-is** — Working Relationship, Version Control & Git, Commit Message Guidelines (format and content rules), Release Notes Process, and the Generated Content section from #67.

**Replaced** — Python Execution, Unit Testing Principles, Shared Code Organization, and the Python-specific parts of Code Implementation Standards. In their place:

- **Local Preview and Validation** — states plainly that there is no test suite and not to go looking for one. Documents `mint dev` and `mint broken-links`, and explains how to read the latter: `/api-reference/*` results are false positives the validator can't resolve, the clean-`main` baseline is 66 flagged links with exactly one genuine (`/foundations-permit-availability`), so **judge against the baseline, not against zero.**
- **A rule that rendered output must be looked at, not merely built.** This one is drawn from #67: a navigation change there built fine, served 200, and passed every programmatic check while silently stranding the new page in a sidebar with no endpoints. Only looking at the page caught it.
- **Content Standards** — frontmatter, Mintlify components, evergreen writing, kebab-case naming, root-relative links, and the `.ai` contact domain.

## Slightly beyond the ticket

The ticket said keep Commit Message Guidelines. I kept the rules but **replaced the seven worked examples**, which were all Python-flavoured (`lib/geo`, `api.app.lib.geo.formatting`, `geo_search/addresses.py`, an `ENG-613` reference). Examples are the part an agent pattern-matches hardest, so leaving them would have undercut the point. The replacements are drawn from real commits in this repo. Easy to revert if you disagree.

## Verification

Every factual claim in the new file was checked against the repo rather than assumed:

- No `package.json` or `pyproject.toml` — confirmed absent.
- `mint broken-links` baseline of 66 — re-run and confirmed.
- Root-relative extensionless internal links — confirmed against existing pages.
- `support@shovels.ai` / `sales@shovels.ai` as the convention — 37 and 26 uses respectively.

Also confirmed all five unfollowable instructions are gone and the Generated Content section survived intact.

Net: 402 lines to 341.
