### PR TITLE
Fix dead contact links in the docs FAQ

### DIFF
--- a/docs/shovels-faq.mdx
+++ b/docs/shovels-faq.mdx
@@ -27,7 +27,7 @@ We talk about this issue in depth [here](/docs/shovels-online-troubleshooting#i-
 - When we do have a jurisdiction in our system, there are varying levels of permit and file digitization, which limits how much data we can process. 
 - Sometimes, the digitized permits we do get are incomplete or garbled, and thus unusable (this is the rarest case, but does happen). 
 
-If you're seeing less-than-desired results, [contact us](mailto:support@shovels.com) and we'll investigate which of the above reasons is the likely culprit, and how we might fix it for you. 
+If you're seeing less-than-desired results, [contact us](mailto:support@shovels.ai) and we'll investigate which of the above reasons is the likely culprit, and how we might fix it for you. 
 
 ## <Icon icon="terminal" size="20px"/> Shovels API
 
@@ -52,7 +52,7 @@ I'll outline a few of the most common ways we see our users interact with the AP
 - **Python scripts**: For more in-depth needs, especially in conjunction with other tools or tasks, Python is a great tool to extract the data you need from the Shovels API and then do something else with it. 
 - **Postman**: [Postman](https://www.postman.com/) is a popular tool for developing and testing APIs, and is often used as an isolated environment prior to integrating it with an existing application or tool. 
 
-At the end of the day, there's no right way to use it, and if you have any questions don't hesitate to [reach out to us for help!](mailto:support@shovels.com)
+At the end of the day, there's no right way to use it, and if you have any questions don't hesitate to [reach out to us for help!](mailto:support@shovels.ai)
 
 ### How do I know how recent the data is?
 
@@ -77,8 +77,8 @@ This will vary based on delivery method (whether you're getting a table share to
 
 It will depend on the data included in the original report, and the nature of the new data that we've added to our system. 
 
-The safest best will be to [Contact Sales](mailto:sales@shovels.com) as we handle these case-by-case.
+The safest best will be to [Contact Sales](mailto:sales@shovels.ai) as we handle these case-by-case.
 
 ## <Icon icon="square-info" size="20px"/> Still Have Questions?
 
-Let us know if there's anything else we can help you with! Our Support team is available to help you with any question you might have, just email us at [support@shovels.com](mailto:support@shovels.com). 
+Let us know if there's anything else we can help you with! Our Support team is available to help you with any question you might have, just email us at [support@shovels.ai](mailto:support@shovels.ai). 

--- a/docs/shovels-faq.mdx
+++ b/docs/shovels-faq.mdx
@@ -77,7 +77,7 @@ This will vary based on delivery method (whether you're getting a table share to
 
 It will depend on the data included in the original report, and the nature of the new data that we've added to our system. 
 
-The safest best will be to [Contact Sales](mailto:sales@shovels.ai) as we handle these case-by-case.
+The safest bet will be to [Contact Sales](mailto:sales@shovels.ai) as we handle these case-by-case.
 
 ## <Icon icon="square-info" size="20px"/> Still Have Questions?
 


### PR DESCRIPTION
Closes [MAR-336](https://linear.app/shovels/issue/MAR-336/fix-dead-contact-links-in-the-docs-faq)

## Why

`docs/shovels-faq.mdx` pointed every contact prompt on the page at `@shovels.com` — a domain Shovels does not own. All four were dead.

| Line | Link |
|---|---|
| 30 | `mailto:support@shovels.com` — "contact us" after a poor-results explanation |
| 55 | `mailto:support@shovels.com` — "reach out to us for help!" |
| 80 | `mailto:sales@shovels.com` — "Contact Sales" |
| 84 | `support@shovels.com` as **both** the visible link text and the `mailto:` href |

This is the FAQ — the page a reader reaches when something has already gone wrong. Every escalation route on it was a dead end. Anyone who followed one got a bounce, and no reason to suspect a wrong address rather than an unresponsive support team.

There is no way to measure what this cost. Nothing logs a message that was never sent.

## What changed

Two commits:

1. **`Fix contact email domain in the FAQ`** — all four occurrences to `support@shovels.ai` / `sales@shovels.ai`, the addresses used consistently everywhere else in the docs. Line 84 needed both the href and the visible text.
2. **`Correct a typo in the FAQ sales prompt`** — line 80 read "The safest **best** will be to Contact Sales". Now "safest **bet**". Same line as one of the dead links, caught while reviewing the fix.

## Deliberately not done

The file has trailing whitespace on most lines and no trailing newline at EOF. Both are pre-existing and file-wide, and neither affects rendered output. Fixing them would bury a four-line change in a ninety-line diff.

## Verification

- **Zero** `shovels.com` references remain anywhere in the repo (`.mdx`, `.json`, `.md`, `.css`).
- Remaining `.com` addresses are all sample data (`john.smith@example.com` and similar), correctly untouched.
- `mint broken-links` unchanged at 66 — the clean-`main` baseline. No new breakage.
