### PR TITLE
State the whole credit model, not just the API half

### DIFF
--- a/docs/knowledge-base/api/basics/request-counts.mdx
+++ b/docs/knowledge-base/api/basics/request-counts.mdx
@@ -1,13 +1,20 @@
 ---
-title: "How Do API Credits Work?"
-description: "The Shovels API uses a record-based credit system. Each record returned counts against your credits—a search returning 100 permits uses 100 credits, while a single permit lookup uses 1."
+title: "How Do Credits Work?"
+description: "One credit is one record. Credits are spent two ways—records returned by the API, and records exported from Shovels Online. Browsing in Shovels Online is free."
 ---
 
-**The Shovels API uses a record-based credit system.** Each record returned by an API call counts against your credits. A permit search that returns 100 results uses 100 credits, while a detail lookup for a single permit uses 1 credit.
+**One credit is one record.** You pay for the records you take, not for the requests you make.
+
+Credits are spent two ways:
+
+- **Records returned by the API.** A permit search that returns 100 results uses 100 credits; a detail lookup for a single permit uses 1.
+- **Records exported from Shovels Online.** A CSV export of 5,000 contractors uses 5,000 credits.
+
+**Everything else is free.** Searching, filtering, paging through results, opening a record, using the map, and asking Charlie cost nothing — browse as much as you like.
 
 ## How Credits Are Counted
 
-Your credits are based on **records returned**, not the number of API calls you make:
+Credits are based on **records**, not on the number of requests you make:
 
 - A search returning **100 permits** = **100 credits used**
 - A search returning **50 contractors** = **50 credits used**
@@ -31,6 +38,12 @@ This applies to all endpoints:
 <Info>
 This applies to every plan, including Free. There is no separate request-based metering.
 </Info>
+
+## Exports From Shovels Online
+
+Exporting search results to CSV spends one credit per record exported, the same rate as the API. The export covers the full set of matching records, so check your remaining balance before exporting a large result set. Export requires a paid plan.
+
+Browsing those same results costs nothing — you only spend credits at the point you take the records out.
 
 ## Managing Your Credits
 
@@ -79,3 +92,5 @@ Credits reset monthly on your subscription or upgrade date.
 
 - [API credit limits](/docs/knowledge-base/api/basics/credit-limits)
 - [Permits per API call](/docs/knowledge-base/api/basics/permits-per-call)
+- [Which Shovels plan is right for me?](/docs/knowledge-base/getting-started/choosing-a-plan)
+- [Permit data downloads](/docs/knowledge-base/shovels-online/permit-downloads)


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Completes the **Credit model behavior** item — the removals shipped in #51 and #49; this is the positive statement of the model, which existed nowhere in the docs.

**This article is already the pricing page's "Learn more" destination.** `shovels.ai/pricing` links its *How credits work* block to `docs.shovels.ai/docs/knowledge-base/api/basics/request-counts`. So the consumer explainer the ticket asks for **already has a home** — a separate new article would fragment the destination rather than serve it. Fixing this one is the ticket item.

**The problem:** the page readers land on contradicted the page that sent them. Pricing says *"1 credit = 1 record, requested via API **or an export in Shovels Online**. Everything else is free."* This article opened *"The Shovels API uses a record-based credit system"* and never mentioned exports or that browsing is free.

**Changes** — `api/basics/request-counts.mdx`, +19/-4:
- Title → **"How Do Credits Work?"** (was "How Do API Credits Work?"); description rewritten to match.
- New lede stating the two ways credits are spent — API records and Shovels Online exports — and, explicitly, that searching, filtering, paging, opening records, the map and Charlie cost nothing.
- New **Exports From Shovels Online** section: one credit per record exported, same rate as the API, covering the full matching set, paid plans only.
- Related Articles now reach `choosing-a-plan` and `permit-downloads`.

**Retitling is safe.** I checked the live page: `#how-do-api-credits-work` **does not exist** as an anchor — Mintlify does not generate one for the page title, so the pricing page's deep link already lands at page top. Nothing regresses.

**Two things for elsewhere, not this PR:**
1. **Marketing has a dead anchor.** That pricing link should drop `#how-do-api-credits-work` or use `#how-credits-are-counted`, which does exist.
2. **This article now sits slightly misfiled.** It covers Shovels Online exports while living in the **API Basics** nav group. Moving it would need a `docs.json` redirect and would change the URL the pricing page links to, so it stays put — flagged as a known tradeoff rather than an oversight.

**Validation:** `mint broken-links` (4.2.3) — clean. Rendered locally. Merges clean with the three sibling PRs opened alongside it.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.