### PR TITLE
Link the plan and licence guides from pricing

### DIFF
--- a/docs/knowledge-base/getting-started/pricing-structure.mdx
+++ b/docs/knowledge-base/getting-started/pricing-structure.mdx
@@ -14,6 +14,8 @@ description: "Shovels Online and the API share credit-based plans—Free, Basic,
 
 For the current price, monthly credits, and seats on each plan, see [shovels.ai/pricing](https://www.shovels.ai/pricing), then [create an account](https://app.shovels.ai/login?mode=register) or [sign in](https://app.shovels.ai/login) to subscribe.
 
+Not sure which one fits? See [Which Shovels plan is right for me?](/docs/knowledge-base/getting-started/choosing-a-plan)
+
 ## How Credits Work
 
 Shovels plans are credit-based: one credit is one record returned. See [How do API credits work?](/docs/knowledge-base/api/basics/request-counts) for how credits are counted and when they reset.
@@ -34,9 +36,7 @@ Every interface below is included on every plan, and they all draw on the same m
 | **Charlie** | Questions in plain English | The AI agent inside Shovels Online |
 
 <Info>
-**When to choose the API vs an EDL:**
-- The **API** is great for looking up addresses and contractors, product integrations, and local lead lists
-- An **EDL** is ideal when you need every contractor across multiple counties with all available fields
+**When to choose the API vs an EDL:** the API is great for looking up addresses and contractors, product integrations, and local lead lists. An EDL is ideal when you need every contractor across multiple counties with all available fields. See [Should I use the API or an EDL?](/docs/knowledge-base/getting-started/api-vs-edl) for the full comparison.
 </Info>
 
 ## Contact Sales

--- a/docs/knowledge-base/index.mdx
+++ b/docs/knowledge-base/index.mdx
@@ -45,6 +45,8 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 ### Getting Started
 - [What makes Shovels different?](/docs/knowledge-base/getting-started/key-differentiators)
 - [How does pricing work?](/docs/knowledge-base/getting-started/pricing-structure)
+- [Which plan is right for me?](/docs/knowledge-base/getting-started/choosing-a-plan)
+- [Should I use the API or an EDL?](/docs/knowledge-base/getting-started/api-vs-edl)
 - [What's included in the Free plan?](/docs/knowledge-base/getting-started/free-trial-guide)
 - [What is Charlie?](/docs/knowledge-base/shovels-online/charlie)
 
@@ -57,7 +59,7 @@ Welcome to the Shovels Knowledge Base. Find quick answers to common questions ab
 
 ### Using the API
 - [How do I access my API key?](/docs/knowledge-base/api/basics/api-key-access)
-- [How do API credits work?](/docs/knowledge-base/api/basics/request-counts)
+- [How do credits work?](/docs/knowledge-base/api/basics/request-counts)
 - [How do I search for permits?](/docs/knowledge-base/api/permits/permit-search)
 - [How do I search for properties?](/docs/knowledge-base/api/properties/property-search)
 - [What does a 422 error mean?](/docs/knowledge-base/api/errors/422-error)


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Closes the inbound-link follow-up owed from #66.

#66 added `choosing-a-plan` and `api-vs-edl` but could reach them through the sidebar only — `pricing-structure.mdx` and `index.mdx` both sat inside #49 at the time, so editing them would have manufactured a conflict across in-flight branches. #49 has merged, so this closes the gap.

**Changes** — +4/-2 across 2 files:
- `getting-started/pricing-structure.mdx`: the Plans section now ends with a pointer to *Which Shovels plan is right for me?*, and the two-bullet API-vs-EDL `<Info>` becomes a short paragraph pointing at the full comparison rather than standing as the only treatment of the question.
- `knowledge-base/index.mdx`: both guides added to Getting Started, between the pricing and Free-plan entries.

Also updates `index.mdx`'s label for `request-counts` from "How do API credits work?" to "How do credits work?", matching the retitle in the sibling PR. If that PR is not merged, this label is simply slightly ahead of the article's title — no link breaks either way, since the path is unchanged.

**Validation:** `mint broken-links` (4.2.3) — clean; both link targets exist in `main`. Rendered locally. Merges clean with the three sibling PRs.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.