### PR TITLE
Say how many results the Free plan can browse

### DIFF
--- a/docs/knowledge-base/getting-started/free-trial-guide.mdx
+++ b/docs/knowledge-base/getting-started/free-trial-guide.mdx
@@ -20,6 +20,10 @@ Users can access the **permit** and **contractor** search functionality from the
 - **Shovels Online**: The Free plan includes access to the last 12 months of permit and contractor data. Paid plans unlock all historical data (on average, 25+ years).
 - **API**: The Free plan includes access to the full historical dataset—no date restrictions.
 
+### Results You Can Browse
+
+A search always reports how many records match, but the Free plan lets you page through the first **10** of them. Paid plans raise that to 100. Narrow your filters to bring a large result set into view, or export the results on a paid plan to work with the full set. See [how Shovels Online works](/docs/knowledge-base/shovels-online/how-it-works) for details.
+
 ### Filters and Sorting
 
 Users can utilize various filters to refine their searches. Filters are available for categories such as:


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Closes the follow-up deferred from #52.

#52 documented the per-plan browsing limits in `how-it-works` and `quick-answers`, but deliberately skipped `free-trial-guide` — three in-flight PRs already touched that file and a fourth adjacent hunk would have manufactured conflicts. Those have merged, so this adds it where a Free reader is most likely to look.

**Changes** — `getting-started/free-trial-guide.mdx`, +5: new **Results You Can Browse** subsection under Features Available on the Free Plan.

It carries the distinction that matters and is easy to miss: a search reports **how many records match**, but the plan caps how many you can page through — 10 on Free, 100 on paid. Undocumented, a result set that stops at 10 while reporting thousands of matches reads as a fault rather than a plan boundary. Points at narrowing filters or exporting on a paid plan, and links `how-it-works` for the fuller treatment rather than restating it.

**Validation:** `mint broken-links` (4.2.3) — clean. Rendered locally. Merges clean with the three sibling PRs.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.