### PR TITLE
Retire the seven-day trial from the walkthrough

### DIFF
--- a/docs/knowledge-base/shovels-online/contractor-downloads.mdx
+++ b/docs/knowledge-base/shovels-online/contractor-downloads.mdx
@@ -75,8 +75,8 @@ This contractor intelligence enables you to:
 
 1. Run your contractor search in Shovels Online
 2. Apply desired filters
-3. Click the download button
-4. Select CSV format
+3. Select **Download CSV**
+4. Choose the export scope and confirm
 
 <Info>
 CSV export requires a paid plan; the export action is unavailable on the Free plan. Exports cover the full set of matching records with no per-export cap, and each exported record spends one credit.

--- a/docs/knowledge-base/shovels-online/permit-downloads.mdx
+++ b/docs/knowledge-base/shovels-online/permit-downloads.mdx
@@ -68,8 +68,8 @@ Duration metrics track:
 
 1. Run your permit search in Shovels Online
 2. Apply desired filters
-3. Click the download button
-4. Select CSV format
+3. Select **Download CSV**
+4. Choose the export scope and confirm
 
 <Info>
 **Exports cover the full set of matching records.** There is no per-export record cap, so you do not need to split a large search into smaller queries. Each exported record spends one credit—check your remaining balance before exporting a large result set.

--- a/docs/shovels-online-quickstart-guide.mdx
+++ b/docs/shovels-online-quickstart-guide.mdx
@@ -28,13 +28,13 @@ For security purposes, we'll send a verification email with a magic link to get 
 
 ### Logging In
 
-Once you've verified your email, you'll be directed to log in. Once successful, you'll officially begin your Free Trial and see the Shovels Online Search page. 
+Once you've verified your email, you'll be directed to log in. Once successful, you'll land on the Shovels Online Search page. 
 
-### Free Trial Usage
+### What the Free Plan Includes
 
-We provide a 7 day Free Trial for all new users, which will allow you to explore the platform, gather some sample data, and get a hang of the data we provide. 
+New accounts start on the Free plan. It doesn't expire and needs no credit card, so you can explore the platform, gather sample data, and get a feel for the data at your own pace.
 
-We also understand that you may need additional time to test and vet the system. If your free trial expires, please reach out to [Sales](mailto:sales@shovels.ai) and we'll be happy to help. 
+On the Free plan you can search permits and contractors across the last 12 months, apply every filter, open individual records, and use the map. Paid plans unlock the full history, raise how many results you can page through, and enable CSV export. See [Which plan is right for me?](/docs/knowledge-base/getting-started/choosing-a-plan) if you're weighing an upgrade.
 
 #### Free Plan API Key
 
@@ -106,7 +106,7 @@ For this example, we'll select "County". A text field will appear, where you can
 
 ### Date Range
 
-This filter allows you to determine the activity range of Contractors you're searching for. In the Free Trial, there are three relative date options: Last 3 Months, Last 6 Months, and Last 12 Months. Subscribed customers have an additional option for "All Time". 
+This filter allows you to determine the activity range of Contractors you're searching for. On the Free plan you can reach back 12 months, with quick options for the last 3, 6, or 12 months. Paid plans can search the full history. 
 
 We'll go with `Last 12 Months`. 
 


### PR DESCRIPTION
Wave 2 of the post-launch KB refresh (MAR-267). Closes the text half of the **Shovels Online — refresh screenshots/walkthroughs** item. Screenshots remain held.

The quickstart described a **7-day Free Trial that expires**. No time-based trial exists in the product: commit `58f8a54` in shovels-online dropped trial fields, and `trialing` survives only as a Stripe subscription status. #49 corrected this file's API-key section but deliberately left these sections, since fixing them meant rewriting a walkthrough rather than replacing a sentence — noted at the time as knowingly half-done. This finishes it.

**Changes** — +7/-8 across 3 files:

`shovels-online-quickstart-guide.mdx`
- **"Free Trial Usage"** → **"What the Free Plan Includes"**. Gone: the 7-day trial, "you'll officially begin your Free Trial", and the "if your free trial expires, reach out to Sales" instruction. Replaced with what is true — the Free plan doesn't expire, needs no card, and covers search, every filter, individual records and the map across the last 12 months, with paid plans unlocking full history, more browsable results and CSV export.
- The contractor date filter no longer frames its options as trial-limited: it described three relative ranges "In the Free Trial" with "All Time" for "Subscribed customers", which reads as a trial restriction rather than the plan's 12-month history window.

`shovels-online/permit-downloads.mdx` and `contractor-downloads.mdx`
- Download steps said *"Click the download button → Select CSV format"*. The real flow is a **Download CSV** button opening a scope dialog; there is no format choice. Both now read *Select **Download CSV** → choose the export scope and confirm*. This was flagged as deliberately out of scope in #51, which corrected the limits above these steps but left the steps themselves.

**Screenshots are untouched**, so the guide's images still show the previous UI. That was the standing instruction; this PR fixes only what the prose asserts.

**Validation:** `grep -rniE "7 day|free trial expires|Free Trial" docs/` returns only an unrelated shell comment about a 7-day permit window. `mint broken-links` (4.2.3) — clean. Rendered locally. Merges clean with the three sibling PRs.

Linear: MAR-267. Reviewer: @rbucks — merge when ready.