### PR TITLE
Track Claude Code shared project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "notion@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
Commits .claude/settings.json so contributors get the repo's shared Claude Code configuration. Personal state stays local via the existing .claude/settings.local.json gitignore rule.